### PR TITLE
feat: add English localization via chrome.i18n API

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,159 +1,159 @@
 {
   "extName": {
     "message": "ANEF Status Tracker",
-    "description": "Nom de l'extension"
+    "description": "Extension name"
   },
   "extDescription": {
-    "message": "Suivez votre statut de naturalisation ANEF en temps réel",
-    "description": "Description de l'extension"
+    "message": "Track your ANEF naturalization status in real time",
+    "description": "Extension description"
   },
 
   "popup_settings_title": {
-    "message": "Paramètres",
+    "message": "Settings",
     "description": "Popup settings button tooltip"
   },
   "popup_maintenance_title": {
-    "message": "Site en maintenance",
+    "message": "Site under maintenance",
     "description": "Popup maintenance screen title"
   },
   "popup_maintenance_desc": {
-    "message": "Le site ANEF est actuellement en maintenance. Veuillez réessayer plus tard.",
+    "message": "The ANEF site is currently under maintenance. Please try again later.",
     "description": "Popup maintenance screen description"
   },
   "popup_retry": {
-    "message": "Réessayer",
+    "message": "Retry",
     "description": "Popup retry button label"
   },
   "popup_password_expired_title": {
-    "message": "Mot de passe expiré",
+    "message": "Password expired",
     "description": "Popup password expired screen title"
   },
   "popup_password_expired_desc": {
-    "message": "Votre mot de passe ANEF a expiré. Connectez-vous sur le portail ANEF pour le renouveler, puis relancez une vérification.",
+    "message": "Your ANEF password has expired. Log in to the ANEF portal to renew it, then retry.",
     "description": "Popup password expired screen description"
   },
   "popup_renew_password": {
-    "message": "Renouveler sur ANEF",
+    "message": "Renew on ANEF",
     "description": "Popup renew password button label"
   },
   "popup_session_expired_title": {
-    "message": "Session expirée",
+    "message": "Session expired",
     "description": "Popup session expired screen title"
   },
   "popup_session_expired_desc": {
-    "message": "Votre session ANEF a expiré. Reconnectez-vous pour actualiser votre statut.",
+    "message": "Your ANEF session has expired. Log in again to refresh your status.",
     "description": "Popup session expired screen description"
   },
   "popup_save_credentials_link": {
-    "message": "Enregistrez vos identifiants",
+    "message": "Save your credentials",
     "description": "Popup link to save credentials"
   },
   "popup_login": {
-    "message": "Se connecter à ANEF",
+    "message": "Log in to ANEF",
     "description": "Popup login button label"
   },
   "popup_login_hint": {
-    "message": "pour une connexion automatique.",
+    "message": "for automatic login.",
     "description": "Popup login hint text after credentials link"
   },
   "popup_no_data_title": {
-    "message": "Aucune donnée",
+    "message": "No data",
     "description": "Popup no data screen title"
   },
   "popup_no_data_desc": {
-    "message": "Visitez votre espace ANEF pour récupérer votre statut.",
+    "message": "Visit your ANEF portal to retrieve your status.",
     "description": "Popup no data screen description"
   },
   "popup_check_status": {
-    "message": "Vérifier mon statut",
+    "message": "Check my status",
     "description": "Popup check status button label"
   },
   "popup_loading_title": {
-    "message": "Actualisation...",
+    "message": "Refreshing...",
     "description": "Popup loading screen title"
   },
   "popup_loading_message": {
-    "message": "Ouverture de la page ANEF...",
+    "message": "Opening the ANEF page...",
     "description": "Popup loading screen message"
   },
   "popup_step_open": {
-    "message": "Ouverture page",
+    "message": "Opening page",
     "description": "Popup loading step: opening page"
   },
   "popup_step_load": {
-    "message": "Chargement",
+    "message": "Loading",
     "description": "Popup loading step: loading"
   },
   "popup_step_data": {
-    "message": "Récupération",
+    "message": "Retrieving",
     "description": "Popup loading step: retrieving data"
   },
   "popup_loading_hint": {
-    "message": "Cette opération peut prendre jusqu'à 45 secondes",
+    "message": "This operation may take up to 45 seconds",
     "description": "Popup loading hint about duration"
   },
   "popup_step_default": {
-    "message": "Étape ?/12",
+    "message": "Step ?/12",
     "description": "Popup default step indicator when step is unknown"
   },
   "popup_progress_start": {
-    "message": "Dépôt",
+    "message": "Filing",
     "description": "Popup progress bar start label"
   },
   "popup_progress_end": {
-    "message": "Décret",
+    "message": "Decree",
     "description": "Popup progress bar end label"
   },
   "popup_status_since": {
-    "message": "Statut depuis",
+    "message": "Status since",
     "description": "Popup label before status date"
   },
   "popup_last_update_label": {
-    "message": "Dernière MAJ",
+    "message": "Last update",
     "description": "Popup last update label"
   },
   "popup_history_incomplete_title": {
-    "message": "Historique incomplet",
+    "message": "Incomplete history",
     "description": "Popup incomplete history banner title"
   },
   "popup_history_incomplete_desc": {
-    "message": "Renseignez vos dates d'étapes passées pour enrichir les statistiques",
+    "message": "Enter your past step dates to enrich statistics",
     "description": "Popup incomplete history banner description"
   },
   "popup_refresh": {
-    "message": "Actualiser",
+    "message": "Refresh",
     "description": "Popup refresh button label"
   },
   "popup_share_title": {
-    "message": "Exporter le suivi en image",
+    "message": "Export tracking as image",
     "description": "Popup share button tooltip"
   },
   "popup_share": {
-    "message": "Partager",
+    "message": "Share",
     "description": "Popup share button label"
   },
   "popup_stat_depot": {
-    "message": "Dépôt",
+    "message": "Filing",
     "description": "Popup stat label for filing date"
   },
   "popup_stat_entretien": {
-    "message": "Entretien",
+    "message": "Interview",
     "description": "Popup stat label for interview date"
   },
   "popup_stat_last_update": {
-    "message": "Dernière MAJ",
+    "message": "Last update",
     "description": "Popup stat label for last update"
   },
   "popup_detail_dossier": {
-    "message": "Dossier",
+    "message": "Case",
     "description": "Popup detail label for case number"
   },
   "popup_detail_national": {
-    "message": "N° National",
+    "message": "National No.",
     "description": "Popup detail label for national number"
   },
   "popup_detail_prefecture": {
-    "message": "Préfecture",
+    "message": "Prefecture",
     "description": "Popup detail label for prefecture"
   },
   "popup_detail_type": {
@@ -161,32 +161,32 @@
     "description": "Popup detail label for request type"
   },
   "popup_detail_location": {
-    "message": "Lieu",
+    "message": "Location",
     "description": "Popup detail label for location"
   },
   "popup_detail_decree": {
-    "message": "Décret",
+    "message": "Decree",
     "description": "Popup detail label for decree"
   },
   "popup_last_check": {
-    "message": "Dernière vérification :",
+    "message": "Last check:",
     "description": "Popup label for last check time"
   },
   "popup_autocheck_settings": {
-    "message": "Modifier dans les paramètres",
+    "message": "Edit in settings",
     "description": "Popup link to edit autocheck in settings"
   },
   "popup_stats_link_title": {
-    "message": "Statistiques communautaires",
+    "message": "Community statistics",
     "description": "Popup community stats link title"
   },
   "popup_stats_link_desc": {
-    "message": "Donnees 100% anonymes — Comparez votre progression",
+    "message": "100% anonymous data — Compare your progress",
     "description": "Popup community stats link description"
   },
 
   "popup_step_format": {
-    "message": "Étape $STEP$/12",
+    "message": "Step $STEP$/12",
     "description": "Popup step indicator with number",
     "placeholders": {
       "step": {
@@ -196,49 +196,49 @@
     }
   },
   "time_today": {
-    "message": "aujourd'hui",
+    "message": "today",
     "description": "Relative time: today"
   },
   "time_ago": {
-    "message": "il y a $DURATION$",
+    "message": "$DURATION$ ago",
     "description": "Relative time: ago",
     "placeholders": {
       "duration": {
         "content": "$1",
-        "example": "3 jours"
+        "example": "3 days"
       }
     }
   },
   "time_in": {
-    "message": "Dans $DURATION$",
+    "message": "In $DURATION$",
     "description": "Relative time: in future",
     "placeholders": {
       "duration": {
         "content": "$1",
-        "example": "5 jours"
+        "example": "5 days"
       }
     }
   },
   "interview_today": {
-    "message": "Aujourd'hui",
+    "message": "Today",
     "description": "Interview date: today"
   },
   "interview_ago": {
-    "message": "Il y a $DURATION$",
+    "message": "$DURATION$ ago",
     "description": "Interview date: ago",
     "placeholders": {
       "duration": {
         "content": "$1",
-        "example": "2 semaines"
+        "example": "2 weeks"
       }
     }
   },
   "popup_never": {
-    "message": "Jamais",
+    "message": "Never",
     "description": "Popup label when no check has been done"
   },
   "popup_attempt": {
-    "message": "tentative $NUM$",
+    "message": "attempt $NUM$",
     "description": "Popup attempt counter lowercase",
     "placeholders": {
       "num": {
@@ -248,7 +248,7 @@
     }
   },
   "popup_attempt_prefix": {
-    "message": "Tentative $NUM$",
+    "message": "Attempt $NUM$",
     "description": "Popup attempt counter capitalized",
     "placeholders": {
       "num": {
@@ -258,19 +258,19 @@
     }
   },
   "popup_password_expired_banner": {
-    "message": "Mot de passe ANEF expiré · renouveler sur le portail",
+    "message": "ANEF password expired · renew on the portal",
     "description": "Popup banner when password is expired"
   },
   "popup_autocheck_creds_required": {
-    "message": "Vérification auto activée · identifiants requis",
+    "message": "Auto-check enabled · credentials required",
     "description": "Popup banner when autocheck needs credentials"
   },
   "popup_autocheck_imminent": {
-    "message": "imminente",
+    "message": "imminent",
     "description": "Popup autocheck timing: imminent"
   },
   "popup_autocheck_minutes": {
-    "message": "dans ~$MINS$ min",
+    "message": "in ~$MINS$ min",
     "description": "Popup autocheck timing: minutes",
     "placeholders": {
       "mins": {
@@ -280,7 +280,7 @@
     }
   },
   "popup_autocheck_hours": {
-    "message": "dans ~$HOURS$h$MINS$",
+    "message": "in ~$HOURS$h$MINS$",
     "description": "Popup autocheck timing: hours and minutes",
     "placeholders": {
       "hours": {
@@ -294,74 +294,74 @@
     }
   },
   "popup_autocheck_next": {
-    "message": "Vérification auto activée · prochaine $TIMING$",
+    "message": "Auto-check enabled · next $TIMING$",
     "description": "Popup autocheck next timing",
     "placeholders": {
       "timing": {
         "content": "$1",
-        "example": "dans ~15 min"
+        "example": "in ~15 min"
       }
     }
   },
   "popup_autocheck_enabled": {
-    "message": "Vérification auto activée",
+    "message": "Auto-check enabled",
     "description": "Popup autocheck enabled label"
   },
   "popup_loading_step1": {
-    "message": "Ouverture de la page ANEF...",
+    "message": "Opening the ANEF page...",
     "description": "Popup loading step 1 text"
   },
   "popup_loading_step2": {
-    "message": "Chargement de la page...",
+    "message": "Loading the page...",
     "description": "Popup loading step 2 text"
   },
   "popup_loading_step3": {
-    "message": "Récupération des données...",
+    "message": "Retrieving data...",
     "description": "Popup loading step 3 text"
   },
   "popup_loading_step4": {
-    "message": "Terminé !",
+    "message": "Done!",
     "description": "Popup loading step 4 text"
   },
   "canvas_depot": {
-    "message": "DÉPÔT",
+    "message": "FILING",
     "description": "Canvas share image: filing label"
   },
   "canvas_entretien": {
-    "message": "ENTRETIEN",
+    "message": "INTERVIEW",
     "description": "Canvas share image: interview label"
   },
   "canvas_entretien_planned": {
-    "message": "ENTRETIEN PRÉVU",
+    "message": "PLANNED INTERVIEW",
     "description": "Canvas share image: planned interview label"
   },
   "canvas_last_update": {
-    "message": "DERNIÈRE MAJ",
+    "message": "LAST UPDATE",
     "description": "Canvas share image: last update label"
   },
   "canvas_date_at": {
-    "message": "à",
+    "message": "at",
     "description": "Date formatting separator between date and time"
   },
 
   "quote_1_text": {
-    "message": "La patience est la clé du bien-être.",
+    "message": "Patience is the key to well-being.",
     "description": "Loading quote 1 text"
   },
   "quote_1_author": {
-    "message": "Mohammed ﷺ",
+    "message": "Prophet Muhammad \uFDFA",
     "description": "Loading quote 1 author"
   },
   "quote_2_text": {
-    "message": "Tout vient à point à qui sait attendre.",
+    "message": "All things come to those who wait.",
     "description": "Loading quote 2 text"
   },
   "quote_2_author": {
-    "message": "Proverbe français",
+    "message": "French proverb",
     "description": "Loading quote 2 author"
   },
   "quote_3_text": {
-    "message": "La patience est amère, mais son fruit est doux.",
+    "message": "Patience is bitter, but its fruit is sweet.",
     "description": "Loading quote 3 text"
   },
   "quote_3_author": {
@@ -369,7 +369,7 @@
     "description": "Loading quote 3 author"
   },
   "quote_4_text": {
-    "message": "Adoptez le rythme de la nature : son secret est la patience.",
+    "message": "Adopt the pace of nature: her secret is patience.",
     "description": "Loading quote 4 text"
   },
   "quote_4_author": {
@@ -377,7 +377,7 @@
     "description": "Loading quote 4 author"
   },
   "quote_5_text": {
-    "message": "La patience est l'art d'espérer.",
+    "message": "Patience is the art of hoping.",
     "description": "Loading quote 5 text"
   },
   "quote_5_author": {
@@ -385,15 +385,15 @@
     "description": "Loading quote 5 author"
   },
   "quote_6_text": {
-    "message": "Ce qui est différé n'est pas perdu.",
+    "message": "What is deferred is not lost.",
     "description": "Loading quote 6 text"
   },
   "quote_6_author": {
-    "message": "Proverbe italien",
+    "message": "Italian proverb",
     "description": "Loading quote 6 author"
   },
   "quote_7_text": {
-    "message": "Les grandes œuvres naissent de la patience.",
+    "message": "Great works are born of patience.",
     "description": "Loading quote 7 text"
   },
   "quote_7_author": {
@@ -401,7 +401,7 @@
     "description": "Loading quote 7 author"
   },
   "quote_8_text": {
-    "message": "La patience et le temps font plus que force ni que rage.",
+    "message": "Patience and time do more than force and rage.",
     "description": "Loading quote 8 text"
   },
   "quote_8_author": {
@@ -409,52 +409,52 @@
     "description": "Loading quote 8 author"
   },
   "quote_9_text": {
-    "message": "Qui va lentement va sûrement.",
+    "message": "Slow and steady wins the race.",
     "description": "Loading quote 9 text"
   },
   "quote_9_author": {
-    "message": "Proverbe latin",
+    "message": "Latin proverb",
     "description": "Loading quote 9 author"
   },
   "quote_10_text": {
-    "message": "La persévérance vient à bout de tout.",
+    "message": "Perseverance conquers all things.",
     "description": "Loading quote 10 text"
   },
   "quote_10_author": {
-    "message": "Proverbe français",
+    "message": "French proverb",
     "description": "Loading quote 10 author"
   },
   "quote_11_text": {
-    "message": "Un voyage de mille lieues commence par un premier pas.",
+    "message": "A journey of a thousand miles begins with a single step.",
     "description": "Loading quote 11 text"
   },
   "quote_11_author": {
-    "message": "Lao Tseu",
+    "message": "Lao Tzu",
     "description": "Loading quote 11 author"
   },
   "quote_12_text": {
-    "message": "L'attente est déjà la moitié du bonheur.",
+    "message": "Waiting is already half of happiness.",
     "description": "Loading quote 12 text"
   },
   "quote_12_author": {
-    "message": "Proverbe chinois",
+    "message": "Chinese proverb",
     "description": "Loading quote 12 author"
   },
 
   "options_page_title": {
-    "message": "ANEF Status Tracker - Paramètres",
+    "message": "ANEF Status Tracker - Settings",
     "description": "Options page HTML title"
   },
   "options_subtitle": {
-    "message": "Paramètres et historique",
+    "message": "Settings and history",
     "description": "Options page subtitle"
   },
   "options_tab_history": {
-    "message": "Historique",
+    "message": "History",
     "description": "Options tab label: history"
   },
   "options_tab_settings": {
-    "message": "Paramètres",
+    "message": "Settings",
     "description": "Options tab label: settings"
   },
   "options_tab_export": {
@@ -466,87 +466,87 @@
     "description": "Options tab label: debug"
   },
   "options_check_log_title": {
-    "message": "Vérifications du jour",
+    "message": "Today's checks",
     "description": "Options section title: today's checks"
   },
   "options_step_dates_title": {
-    "message": "Mes dates d'étapes",
+    "message": "My step dates",
     "description": "Options section title: step dates"
   },
   "options_pull_dates": {
-    "message": "Récupérer",
+    "message": "Retrieve",
     "description": "Options button: pull dates from database"
   },
   "options_save_dates": {
-    "message": "Enregistrer",
+    "message": "Save",
     "description": "Options button: save step dates"
   },
   "options_step_dates_hint": {
-    "message": "Renseignez les dates de vos changements d'étape pour enrichir les statistiques communautaires.",
+    "message": "Enter the dates of your step changes to enrich community statistics.",
     "description": "Options step dates hint text"
   },
   "options_history_title": {
-    "message": "Historique des statuts",
+    "message": "Status history",
     "description": "Options section title: status history"
   },
   "options_no_history": {
-    "message": "Aucun historique disponible",
+    "message": "No history available",
     "description": "Options empty history message"
   },
   "options_no_history_hint": {
-    "message": "Visitez le site ANEF pour commencer à enregistrer votre historique.",
+    "message": "Visit the ANEF site to start recording your history.",
     "description": "Options empty history hint"
   },
   "options_settings_title": {
-    "message": "Paramètres",
+    "message": "Settings",
     "description": "Options section title: settings"
   },
   "options_auto_login_title": {
-    "message": "Connexion automatique",
+    "message": "Automatic login",
     "description": "Options auto-login section title"
   },
   "options_auto_login_desc": {
-    "message": "Enregistrez vos identifiants ANEF pour permettre l'actualisation automatique même si votre session a expiré.",
+    "message": "Save your ANEF credentials to enable automatic refresh even if your session has expired.",
     "description": "Options auto-login section description"
   },
   "options_username_label": {
-    "message": "Numéro étranger",
+    "message": "Foreign number",
     "description": "Options username field label"
   },
   "options_username_desc": {
-    "message": "Votre identifiant de connexion ANEF",
+    "message": "Your ANEF login ID",
     "description": "Options username field description"
   },
   "options_username_placeholder": {
-    "message": "Ex: 0123456789",
+    "message": "e.g. 0123456789",
     "description": "Options username field placeholder"
   },
   "options_password_label": {
-    "message": "Mot de passe",
+    "message": "Password",
     "description": "Options password field label"
   },
   "options_password_placeholder": {
-    "message": "••••••••",
+    "message": "\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022",
     "description": "Options password field placeholder"
   },
   "options_toggle_password": {
-    "message": "Afficher/Masquer",
+    "message": "Show/Hide",
     "description": "Options toggle password visibility button"
   },
   "options_no_credentials": {
-    "message": "Aucun identifiant enregistré",
+    "message": "No credentials saved",
     "description": "Options label when no credentials saved"
   },
   "options_save": {
-    "message": "Enregistrer",
+    "message": "Save",
     "description": "Options save button label"
   },
   "options_delete": {
-    "message": "Supprimer",
+    "message": "Delete",
     "description": "Options delete button label"
   },
   "options_credential_warning": {
-    "message": "Vos identifiants sont stockés localement sur votre appareil et ne sont jamais envoyés à des serveurs externes.",
+    "message": "Your credentials are stored locally on your device and are never sent to external servers.",
     "description": "Options credential security notice"
   },
   "options_notifications_title": {
@@ -554,170 +554,170 @@
     "description": "Options notifications section title"
   },
   "options_notifications_label": {
-    "message": "Activer les notifications",
+    "message": "Enable notifications",
     "description": "Options notifications toggle label"
   },
   "options_notifications_desc": {
-    "message": "Recevoir une notification lors d'un changement de statut",
+    "message": "Receive a notification when your status changes",
     "description": "Options notifications toggle description"
   },
   "options_autocheck_title": {
-    "message": "Vérification automatique",
+    "message": "Automatic check",
     "description": "Options autocheck section title"
   },
   "options_autocheck_label": {
-    "message": "Vérifier automatiquement",
+    "message": "Check automatically",
     "description": "Options autocheck toggle label"
   },
   "options_autocheck_desc": {
-    "message": "Vérifie votre statut ~3 fois par jour en arrière-plan",
+    "message": "Checks your status ~3 times a day in the background",
     "description": "Options autocheck toggle description"
   },
   "options_autocheck_no_creds": {
-    "message": "Des identifiants enregistrés sont nécessaires pour la vérification automatique.",
+    "message": "Saved credentials are required for automatic checking.",
     "description": "Options autocheck warning when no credentials"
   },
   "options_autocheck_password_expired": {
-    "message": "Mot de passe ANEF expiré",
+    "message": "ANEF password expired",
     "description": "Options autocheck password expired notice"
   },
   "options_autocheck_reset": {
-    "message": "Réinitialiser",
+    "message": "Reset",
     "description": "Options autocheck reset button label"
   },
   "options_stats_title": {
-    "message": "Statistiques communautaires",
+    "message": "Community statistics",
     "description": "Options community stats section title"
   },
   "options_stats_warning": {
-    "message": "Les statistiques anonymes sont partagées automatiquement pour alimenter les données communautaires. Données envoyées : étape, dates (jour uniquement), préfecture. Votre numéro de dossier est remplacé par un hash irréversible.",
+    "message": "Anonymous statistics are shared automatically to feed community data. Data sent: step, dates (day only), prefecture. Your case number is replaced with an irreversible hash.",
     "description": "Options community stats privacy notice"
   },
   "options_stats_link": {
-    "message": "Voir les statistiques",
+    "message": "View statistics",
     "description": "Options community stats link label"
   },
   "options_general_title": {
-    "message": "Général",
+    "message": "General",
     "description": "Options general section title"
   },
   "options_history_limit_label": {
-    "message": "Limite de l'historique",
+    "message": "History limit",
     "description": "Options history limit setting label"
   },
   "options_history_limit_desc": {
-    "message": "Nombre maximum d'entrées à conserver",
+    "message": "Maximum number of entries to keep",
     "description": "Options history limit setting description"
   },
   "options_entries_50": {
-    "message": "50 entrées",
+    "message": "50 entries",
     "description": "Options history limit option: 50"
   },
   "options_entries_100": {
-    "message": "100 entrées",
+    "message": "100 entries",
     "description": "Options history limit option: 100"
   },
   "options_entries_200": {
-    "message": "200 entrées",
+    "message": "200 entries",
     "description": "Options history limit option: 200"
   },
   "options_entries_500": {
-    "message": "500 entrées",
+    "message": "500 entries",
     "description": "Options history limit option: 500"
   },
   "options_save_settings": {
-    "message": "Sauvegarder",
+    "message": "Save",
     "description": "Options save settings button label"
   },
   "options_reset_settings": {
-    "message": "Réinitialiser",
+    "message": "Reset",
     "description": "Options reset settings button label"
   },
   "options_export_title": {
-    "message": "Exporter / Importer",
+    "message": "Export / Import",
     "description": "Options export section title"
   },
   "options_export_data_title": {
-    "message": "Exporter les données",
+    "message": "Export data",
     "description": "Options export data subsection title"
   },
   "options_export_data_desc": {
-    "message": "Téléchargez une sauvegarde de toutes vos données (historique, paramètres).",
+    "message": "Download a backup of all your data (history, settings).",
     "description": "Options export data description"
   },
   "options_export_json": {
-    "message": "Exporter (JSON)",
+    "message": "Export (JSON)",
     "description": "Options export JSON button label"
   },
   "options_import_title": {
-    "message": "Importer des données",
+    "message": "Import data",
     "description": "Options import data subsection title"
   },
   "options_import_desc": {
-    "message": "Restaurez vos données depuis un fichier de sauvegarde.",
+    "message": "Restore your data from a backup file.",
     "description": "Options import data description"
   },
   "options_import": {
-    "message": "Importer",
+    "message": "Import",
     "description": "Options import button label"
   },
   "options_danger_title": {
-    "message": "Zone de danger",
+    "message": "Danger zone",
     "description": "Options danger zone section title"
   },
   "options_danger_desc": {
-    "message": "Supprimer toutes les données de l'extension.",
+    "message": "Delete all extension data.",
     "description": "Options danger zone description"
   },
   "options_delete_all": {
-    "message": "Tout supprimer",
+    "message": "Delete all",
     "description": "Options delete all data button label"
   },
   "options_debug_title": {
-    "message": "Logs de debug",
+    "message": "Debug logs",
     "description": "Options debug section title"
   },
   "options_refresh_logs": {
-    "message": "Actualiser",
+    "message": "Refresh",
     "description": "Options refresh logs button label"
   },
   "options_clear_logs": {
-    "message": "Effacer",
+    "message": "Clear",
     "description": "Options clear logs button label"
   },
   "options_debug_info": {
-    "message": "Ces logs aident à diagnostiquer les problèmes de l'extension.",
+    "message": "These logs help diagnose extension issues.",
     "description": "Options debug info text"
   },
   "options_no_logs": {
-    "message": "Aucun log disponible",
+    "message": "No logs available",
     "description": "Options empty debug logs message"
   },
 
   "options_last_check_banner": {
-    "message": "Dernière vérification : ",
+    "message": "Last check: ",
     "description": "Options banner showing last check time"
   },
   "options_since": {
-    "message": "Depuis le $DATE$",
+    "message": "Since $DATE$",
     "description": "Options label: since date",
     "placeholders": {
       "date": {
         "content": "$1",
-        "example": "15/03/2026"
+        "example": "03/15/2026"
       }
     }
   },
   "options_date_unknown": {
-    "message": "Date inconnue",
+    "message": "Unknown date",
     "description": "Options label when date is unknown"
   },
   "options_step_label": {
-    "message": "étape",
+    "message": "step",
     "description": "Options step label lowercase"
   },
   "options_step_total": {
-    "message": "sur 12",
+    "message": "of 12",
     "description": "Options step total suffix"
   },
   "options_badge_auto": {
@@ -725,15 +725,15 @@
     "description": "Options history badge: automatic check"
   },
   "options_badge_manual": {
-    "message": "Manuel",
+    "message": "Manual",
     "description": "Options history badge: manual check"
   },
   "options_badge_rectified": {
-    "message": "Rectifié",
+    "message": "Corrected",
     "description": "Options history badge: corrected entry"
   },
   "options_step_sub": {
-    "message": "Étape $NUM$",
+    "message": "Step $NUM$",
     "description": "Options step label with number",
     "placeholders": {
       "num": {
@@ -743,23 +743,23 @@
     }
   },
   "options_dates_chronological": {
-    "message": "Les dates doivent être chronologiques",
+    "message": "Dates must be in chronological order",
     "description": "Options validation error: dates order"
   },
   "options_date_cannot_delete": {
-    "message": "Une date déjà enregistrée ne peut pas être supprimée",
+    "message": "A previously saved date cannot be deleted",
     "description": "Options validation error: cannot delete saved date"
   },
   "options_dates_saved": {
-    "message": "Dates enregistrées et synchronisées",
+    "message": "Dates saved and synced",
     "description": "Options success: dates saved"
   },
   "options_loading": {
-    "message": "Chargement...",
+    "message": "Loading...",
     "description": "Options generic loading message"
   },
   "options_dates_pulled": {
-    "message": "$COUNT$ date(s) récupérée(s) depuis la base",
+    "message": "$COUNT$ date(s) retrieved from database",
     "description": "Options success: dates pulled from database",
     "placeholders": {
       "count": {
@@ -769,63 +769,63 @@
     }
   },
   "options_no_data_found": {
-    "message": "Aucune donnée trouvée dans la base",
+    "message": "No data found in database",
     "description": "Options notice: no data found in database"
   },
   "options_connection_error": {
-    "message": "Erreur de connexion",
+    "message": "Connection error",
     "description": "Options error: connection failed"
   },
   "options_settings_saved": {
-    "message": "Paramètres sauvegardés",
+    "message": "Settings saved",
     "description": "Options success: settings saved"
   },
   "options_confirm_reset": {
-    "message": "Réinitialiser les paramètres par défaut ?",
+    "message": "Reset to default settings?",
     "description": "Options confirm dialog: reset settings"
   },
   "options_settings_reset": {
-    "message": "Paramètres réinitialisés",
+    "message": "Settings reset",
     "description": "Options success: settings reset"
   },
   "options_credentials_saved": {
-    "message": "Identifiants enregistrés",
+    "message": "Credentials saved",
     "description": "Options success: credentials saved"
   },
   "options_no_credentials_saved": {
-    "message": "Aucun identifiant enregistré",
+    "message": "No credentials saved",
     "description": "Options notice: no credentials saved"
   },
   "options_fill_all_fields": {
-    "message": "Veuillez remplir tous les champs",
+    "message": "Please fill in all fields",
     "description": "Options validation error: fill all fields"
   },
   "options_save_error": {
-    "message": "Erreur lors de la sauvegarde",
+    "message": "Error while saving",
     "description": "Options error: save failed"
   },
   "options_confirm_delete_creds": {
-    "message": "Supprimer vos identifiants ?",
+    "message": "Delete your credentials?",
     "description": "Options confirm dialog: delete credentials"
   },
   "options_credentials_deleted": {
-    "message": "Identifiants supprimés",
+    "message": "Credentials deleted",
     "description": "Options success: credentials deleted"
   },
   "options_delete_error": {
-    "message": "Erreur lors de la suppression",
+    "message": "Error while deleting",
     "description": "Options error: delete failed"
   },
   "options_password_expired_msg": {
-    "message": "Mot de passe ANEF expiré — renouveler sur le portail",
+    "message": "ANEF password expired \u2014 renew on the portal",
     "description": "Options password expired banner message"
   },
   "options_password_expired_short": {
-    "message": "Mot de passe expiré",
+    "message": "Password expired",
     "description": "Options password expired short label"
   },
   "options_failures_next": {
-    "message": "$COUNT$ échec(s) · prochaine tentative dans ~$MINS$ min",
+    "message": "$COUNT$ failure(s) \u00b7 next attempt in ~$MINS$ min",
     "description": "Options autocheck failures with next attempt time",
     "placeholders": {
       "count": {
@@ -839,11 +839,11 @@
     }
   },
   "options_next_check_imminent": {
-    "message": "Prochaine vérification imminente",
+    "message": "Next check imminent",
     "description": "Options autocheck next: imminent"
   },
   "options_next_check_minutes": {
-    "message": "Prochaine vérification dans ~$MINS$ min",
+    "message": "Next check in ~$MINS$ min",
     "description": "Options autocheck next: minutes",
     "placeholders": {
       "mins": {
@@ -853,7 +853,7 @@
     }
   },
   "options_next_check_hours": {
-    "message": "Prochaine vérification dans ~$HOURS$h$MINS$",
+    "message": "Next check in ~$HOURS$h$MINS$",
     "description": "Options autocheck next: hours and minutes",
     "placeholders": {
       "hours": {
@@ -867,72 +867,72 @@
     }
   },
   "options_waiting_schedule": {
-    "message": "En attente de programmation",
+    "message": "Waiting to be scheduled",
     "description": "Options autocheck: waiting to be scheduled"
   },
   "options_autocheck_reactivated": {
-    "message": "Vérification automatique réactivée",
+    "message": "Automatic check reactivated",
     "description": "Options success: autocheck reactivated"
   },
   "options_reactivation_error": {
-    "message": "Erreur lors de la réactivation",
+    "message": "Error while reactivating",
     "description": "Options error: reactivation failed"
   },
   "options_export_success": {
-    "message": "Export réussi",
+    "message": "Export successful",
     "description": "Options success: export completed"
   },
   "options_export_error": {
-    "message": "Erreur lors de l'export",
+    "message": "Error while exporting",
     "description": "Options error: export failed"
   },
   "options_invalid_file": {
-    "message": "Fichier invalide",
+    "message": "Invalid file",
     "description": "Options error: invalid import file"
   },
   "options_import_success": {
-    "message": "Import réussi",
+    "message": "Import successful",
     "description": "Options success: import completed"
   },
   "options_import_error": {
-    "message": "Erreur lors de l'import",
+    "message": "Error while importing",
     "description": "Options error: import failed"
   },
   "options_confirm_delete_all": {
-    "message": "Supprimer toutes les données (historique, paramètres) ?\nVos identifiants de connexion seront conservés.\nCette action est irréversible.",
+    "message": "Delete all data (history, settings)?\nYour login credentials will be kept.\nThis action is irreversible.",
     "description": "Options confirm dialog: delete all data"
   },
   "options_data_deleted": {
-    "message": "Données supprimées (identifiants conservés)",
+    "message": "Data deleted (credentials kept)",
     "description": "Options success: all data deleted"
   },
   "options_log_error": {
-    "message": "Erreur de chargement",
+    "message": "Loading error",
     "description": "Options error: log loading failed"
   },
   "options_logs_cleared": {
-    "message": "Logs effacés",
+    "message": "Logs cleared",
     "description": "Options success: logs cleared"
   },
   "options_unsaved": {
-    "message": "Modifications non enregistrées",
+    "message": "Unsaved changes",
     "description": "Options warning: unsaved changes"
   },
   "options_rectify_date": {
-    "message": "Rectifier la date",
+    "message": "Correct the date",
     "description": "Options button: correct a date"
   },
 
   "notification_status_change": {
-    "message": "Changement de statut ANEF !",
+    "message": "ANEF status change!",
     "description": "Notification title for status change"
   },
   "notification_congratulations": {
-    "message": "FÉLICITATIONS !",
+    "message": "CONGRATULATIONS!",
     "description": "Notification title for naturalization"
   },
   "notification_update": {
-    "message": "Mise à jour de votre dossier",
+    "message": "Update on your case",
     "description": "Notification title for case update"
   },
   "notification_body": {
@@ -941,21 +941,21 @@
     "placeholders": {
       "phase": {
         "content": "$1",
-        "example": "Contrôle SDANF"
+        "example": "SDANF Review"
       },
       "explication": {
         "content": "$2",
-        "example": "Contrôle ministériel en cours"
+        "example": "Ministerial review in progress"
       }
     }
   },
 
   "duration_today": {
-    "message": "aujourd'hui",
+    "message": "today",
     "description": "Duration formatting: today"
   },
   "duration_year_one": {
-    "message": "$COUNT$ an",
+    "message": "$COUNT$ year",
     "description": "Duration formatting: one year",
     "placeholders": {
       "count": {
@@ -965,7 +965,7 @@
     }
   },
   "duration_year_other": {
-    "message": "$COUNT$ ans",
+    "message": "$COUNT$ years",
     "description": "Duration formatting: multiple years",
     "placeholders": {
       "count": {
@@ -975,7 +975,7 @@
     }
   },
   "duration_month": {
-    "message": "$COUNT$ mois",
+    "message": "$COUNT$ month(s)",
     "description": "Duration formatting: months",
     "placeholders": {
       "count": {
@@ -985,7 +985,7 @@
     }
   },
   "duration_day_one": {
-    "message": "$COUNT$ jour",
+    "message": "$COUNT$ day",
     "description": "Duration formatting: one day",
     "placeholders": {
       "count": {
@@ -995,7 +995,7 @@
     }
   },
   "duration_day_other": {
-    "message": "$COUNT$ jours",
+    "message": "$COUNT$ days",
     "description": "Duration formatting: multiple days",
     "placeholders": {
       "count": {
@@ -1006,613 +1006,613 @@
   },
 
   "status_draft_phase": {
-    "message": "Brouillon",
+    "message": "Draft",
     "description": "Status phase for draft"
   },
   "status_draft_explication": {
-    "message": "Dossier en brouillon",
+    "message": "Case in draft",
     "description": "Status explanation for draft"
   },
   "status_draft_description": {
-    "message": "Votre dossier est en cours de préparation sur la plateforme ANEF. Complétez toutes les sections et joignez les pièces justificatives avant de soumettre.",
+    "message": "Your case is being prepared on the ANEF platform. Complete all sections and attach the required documents before submitting.",
     "description": "Status full description for draft"
   },
   "status_dossier_depose_phase": {
-    "message": "Dépôt",
+    "message": "Filing",
     "description": "Status phase for dossier_depose"
   },
   "status_dossier_depose_explication": {
-    "message": "Dossier déposé",
+    "message": "Case filed",
     "description": "Status explanation for dossier_depose"
   },
   "status_dossier_depose_description": {
-    "message": "Votre dossier a été soumis avec succès. Il est dans la file d'attente de la préfecture pour un premier examen de recevabilité.",
+    "message": "Your case has been successfully submitted. It is in the prefecture's queue for initial admissibility review.",
     "description": "Status full description for dossier_depose"
   },
   "status_verification_formelle_a_traiter_phase": {
-    "message": "Vérification formelle",
+    "message": "Formal verification",
     "description": "Status phase for verification_formelle_a_traiter"
   },
   "status_verification_formelle_a_traiter_explication": {
-    "message": "Dossier reçu, en tri",
+    "message": "Case received, being sorted",
     "description": "Status explanation for verification_formelle_a_traiter"
   },
   "status_verification_formelle_a_traiter_description": {
-    "message": "La préfecture a bien reçu votre demande. Elle est placée en file d'attente pour le premier tri administratif : vérification des pièces obligatoires et conditions de base.",
+    "message": "The prefecture has received your application. It has been placed in the queue for initial administrative sorting: verification of mandatory documents and basic conditions.",
     "description": "Status full description for verification_formelle_a_traiter"
   },
   "status_verification_formelle_en_cours_phase": {
-    "message": "Vérification formelle",
+    "message": "Formal verification",
     "description": "Status phase for verification_formelle_en_cours"
   },
   "status_verification_formelle_en_cours_explication": {
-    "message": "Tri en cours",
+    "message": "Sorting in progress",
     "description": "Status explanation for verification_formelle_en_cours"
   },
   "status_verification_formelle_en_cours_description": {
-    "message": "Un agent vérifie l'admissibilité formelle de votre dossier : présence des documents requis, validité des pièces, conditions légales. Des compléments peuvent être demandés.",
+    "message": "An officer is verifying the formal admissibility of your case: presence of required documents, validity of documents, legal conditions. Additional documents may be requested.",
     "description": "Status full description for verification_formelle_en_cours"
   },
   "status_verification_formelle_mise_en_demeure_phase": {
-    "message": "Vérification formelle",
+    "message": "Formal verification",
     "description": "Status phase for verification_formelle_mise_en_demeure"
   },
   "status_verification_formelle_mise_en_demeure_explication": {
-    "message": "Mise en demeure, pièces à fournir",
+    "message": "Formal notice, documents required",
     "description": "Status explanation for verification_formelle_mise_en_demeure"
   },
   "status_verification_formelle_mise_en_demeure_description": {
-    "message": "Des documents obligatoires sont manquants ou non conformes. Vous allez recevoir un courrier détaillant les pièces à fournir. Répondez dans le délai imparti pour éviter un classement sans suite.",
+    "message": "Mandatory documents are missing or non-compliant. You will receive a letter detailing the required documents. Respond within the given deadline to avoid case closure.",
     "description": "Status full description for verification_formelle_mise_en_demeure"
   },
   "status_css_mise_en_demeure_a_affecter_phase": {
-    "message": "Vérification formelle",
+    "message": "Formal verification",
     "description": "Status phase for css_mise_en_demeure_a_affecter"
   },
   "status_css_mise_en_demeure_a_affecter_explication": {
-    "message": "Classement sans suite en cours",
+    "message": "Case closure in progress",
     "description": "Status explanation for css_mise_en_demeure_a_affecter"
   },
   "status_css_mise_en_demeure_a_affecter_description": {
-    "message": "Suite à la mise en demeure restée sans réponse, un classement sans suite est en cours d'affectation à un agent. Fournissez les pièces manquantes au plus vite.",
+    "message": "Following the unanswered formal notice, a case closure is being assigned to an officer. Provide the missing documents as soon as possible.",
     "description": "Status full description for css_mise_en_demeure_a_affecter"
   },
   "status_css_mise_en_demeure_a_rediger_phase": {
-    "message": "Vérification formelle",
+    "message": "Formal verification",
     "description": "Status phase for css_mise_en_demeure_a_rediger"
   },
   "status_css_mise_en_demeure_a_rediger_explication": {
-    "message": "Classement sans suite en rédaction",
+    "message": "Case closure being drafted",
     "description": "Status explanation for css_mise_en_demeure_a_rediger"
   },
   "status_css_mise_en_demeure_a_rediger_description": {
-    "message": "Le classement sans suite de votre dossier est en cours de rédaction suite à l'absence de réponse à la mise en demeure. Contactez votre préfecture si vous avez transmis les pièces.",
+    "message": "The closure of your case is being drafted following the unanswered formal notice. Contact your prefecture if you have submitted the documents.",
     "description": "Status full description for css_mise_en_demeure_a_rediger"
   },
   "status_instruction_a_affecter_phase": {
-    "message": "Affectation",
+    "message": "Assignment",
     "description": "Status phase for instruction_a_affecter"
   },
   "status_instruction_a_affecter_explication": {
-    "message": "Dossier recevable, attente d'affectation",
+    "message": "Case admissible, awaiting assignment",
     "description": "Status explanation for instruction_a_affecter"
   },
   "status_instruction_a_affecter_description": {
-    "message": "Votre dossier a passé la vérification formelle avec succès ! Il est déclaré recevable et attend d'être attribué à un agent instructeur pour un examen approfondi. Vous recevrez un récépissé de dépôt.",
+    "message": "Your case has passed the formal verification! It is declared admissible and is waiting to be assigned to a reviewing officer for in-depth examination. You will receive an acknowledgment of receipt.",
     "description": "Status full description for instruction_a_affecter"
   },
   "status_instruction_recepisse_completude_a_envoyer_phase": {
-    "message": "Instruction",
+    "message": "Review",
     "description": "Status phase for instruction_recepisse_completude_a_envoyer"
   },
   "status_instruction_recepisse_completude_a_envoyer_explication": {
-    "message": "Dossier complet, examen approfondi",
+    "message": "Complete case, in-depth review",
     "description": "Status explanation for instruction_recepisse_completude_a_envoyer"
   },
   "status_instruction_recepisse_completude_a_envoyer_description": {
-    "message": "Un agent instructeur examine en détail votre dossier : situation personnelle, professionnelle, fiscale, assimilation. Le récépissé de complétude sera envoyé. Il peut vous convoquer pour l'entretien.",
+    "message": "A reviewing officer is examining your case in detail: personal, professional, tax situation, and assimilation. The completeness receipt will be sent. You may be summoned for an interview.",
     "description": "Status full description for instruction_recepisse_completude_a_envoyer"
   },
   "status_instruction_recepisse_completude_a_envoyer_retour_complement_a_traiter_phase": {
-    "message": "Instruction",
+    "message": "Review",
     "description": "Status phase for instruction_recepisse_completude_a_envoyer_retour_complement_a_traiter"
   },
   "status_instruction_recepisse_completude_a_envoyer_retour_complement_a_traiter_explication": {
-    "message": "Compléments reçus, à vérifier",
+    "message": "Additional documents received, to be verified",
     "description": "Status explanation for instruction_recepisse_completude_a_envoyer_retour_complement_a_traiter"
   },
   "status_instruction_recepisse_completude_a_envoyer_retour_complement_a_traiter_description": {
-    "message": "Vous avez fourni des documents complémentaires suite à une demande de l'instructeur. L'agent vérifie leur conformité avant de poursuivre l'instruction de votre dossier.",
+    "message": "You have provided additional documents as requested by the reviewing officer. The officer is verifying their compliance before continuing the review of your case.",
     "description": "Status full description for instruction_recepisse_completude_a_envoyer_retour_complement_a_traiter"
   },
   "status_instruction_date_ea_a_fixer_phase": {
-    "message": "Complétude & enquêtes",
+    "message": "Completeness & inquiries",
     "description": "Status phase for instruction_date_ea_a_fixer"
   },
   "status_instruction_date_ea_a_fixer_explication": {
-    "message": "Enquêtes administratives lancées",
+    "message": "Administrative inquiries launched",
     "description": "Status explanation for instruction_date_ea_a_fixer"
   },
   "status_instruction_date_ea_a_fixer_description": {
-    "message": "Votre dossier est officiellement complet ! Les enquêtes administratives obligatoires sont lancées (casier judiciaire, renseignements, fichiers). La date d'entretien d'assimilation sera fixée prochainement.",
+    "message": "Your case is officially complete! Mandatory administrative inquiries have been launched (criminal record, intelligence, databases). The assimilation interview date will be set soon.",
     "description": "Status full description for instruction_date_ea_a_fixer"
   },
   "status_ea_demande_report_ea_phase": {
-    "message": "Complétude & enquêtes",
+    "message": "Completeness & inquiries",
     "description": "Status phase for ea_demande_report_ea"
   },
   "status_ea_demande_report_ea_explication": {
-    "message": "Demande de report d'entretien",
+    "message": "Interview postponement requested",
     "description": "Status explanation for ea_demande_report_ea"
   },
   "status_ea_demande_report_ea_description": {
-    "message": "Une demande de report de l'entretien d'assimilation a été enregistrée. La préfecture vous proposera une nouvelle date. Attention aux délais pour ne pas retarder votre dossier.",
+    "message": "A request to postpone the assimilation interview has been recorded. The prefecture will propose a new date. Be mindful of deadlines to avoid delaying your case.",
     "description": "Status full description for ea_demande_report_ea"
   },
   "status_ea_en_attente_ea_phase": {
-    "message": "Entretien d'assimilation",
+    "message": "Assimilation interview",
     "description": "Status phase for ea_en_attente_ea"
   },
   "status_ea_en_attente_ea_explication": {
-    "message": "Convocation envoyée, en attente",
+    "message": "Summons sent, awaiting interview",
     "description": "Status explanation for ea_en_attente_ea"
   },
   "status_ea_en_attente_ea_description": {
-    "message": "Votre convocation à l'entretien d'assimilation est envoyée ou disponible. Préparez-vous : questions sur la France (histoire, culture, valeurs républicaines), votre parcours et vos motivations.",
+    "message": "Your summons for the assimilation interview has been sent or is available. Prepare yourself: questions about France (history, culture, republican values), your background, and your motivations.",
     "description": "Status full description for ea_en_attente_ea"
   },
   "status_ea_crea_a_valider_phase": {
-    "message": "Entretien d'assimilation",
+    "message": "Assimilation interview",
     "description": "Status phase for ea_crea_a_valider"
   },
   "status_ea_crea_a_valider_explication": {
-    "message": "Entretien passé, compte-rendu en rédaction",
+    "message": "Interview completed, report being drafted",
     "description": "Status explanation for ea_crea_a_valider"
   },
   "status_ea_crea_a_valider_description": {
-    "message": "Vous avez passé l'entretien d'assimilation ! L'agent rédige le compte-rendu évaluant votre niveau de langue, connaissance de la France et assimilation à la communauté française.",
+    "message": "You have completed the assimilation interview! The officer is drafting the report evaluating your language level, knowledge of France, and assimilation into the French community.",
     "description": "Status full description for ea_crea_a_valider"
   },
   "status_prop_decision_pref_a_effectuer_phase": {
-    "message": "Décision préfecture",
+    "message": "Prefecture decision",
     "description": "Status phase for prop_decision_pref_a_effectuer"
   },
   "status_prop_decision_pref_a_effectuer_explication": {
-    "message": "Avis préfectoral en cours",
+    "message": "Prefectural opinion in progress",
     "description": "Status explanation for prop_decision_pref_a_effectuer"
   },
   "status_prop_decision_pref_a_effectuer_description": {
-    "message": "L'agent instructeur analyse l'ensemble de votre dossier (enquêtes, entretien, pièces) pour formuler sa proposition d'avis : favorable, défavorable ou ajournement.",
+    "message": "The reviewing officer is analyzing your entire case (inquiries, interview, documents) to formulate a recommendation: favorable, unfavorable, or deferral.",
     "description": "Status full description for prop_decision_pref_a_effectuer"
   },
   "status_prop_decision_pref_en_attente_retour_hierarchique_phase": {
-    "message": "Décision préfecture",
+    "message": "Prefecture decision",
     "description": "Status phase for prop_decision_pref_en_attente_retour_hierarchique"
   },
   "status_prop_decision_pref_en_attente_retour_hierarchique_explication": {
-    "message": "Validation hiérarchique en cours",
+    "message": "Hierarchical validation in progress",
     "description": "Status explanation for prop_decision_pref_en_attente_retour_hierarchique"
   },
   "status_prop_decision_pref_en_attente_retour_hierarchique_description": {
-    "message": "La proposition de l'agent est soumise à sa hiérarchie pour validation. Cette étape permet de confirmer l'avis avant transmission au préfet. Durée variable selon les préfectures.",
+    "message": "The officer's recommendation is submitted to their hierarchy for validation. This step confirms the opinion before transmission to the prefect. Duration varies by prefecture.",
     "description": "Status full description for prop_decision_pref_en_attente_retour_hierarchique"
   },
   "status_prop_decision_pref_prop_a_editer_phase": {
-    "message": "Décision préfecture",
+    "message": "Prefecture decision",
     "description": "Status phase for prop_decision_pref_prop_a_editer"
   },
   "status_prop_decision_pref_prop_a_editer_explication": {
-    "message": "Rédaction de la proposition",
+    "message": "Recommendation being drafted",
     "description": "Status explanation for prop_decision_pref_prop_a_editer"
   },
   "status_prop_decision_pref_prop_a_editer_description": {
-    "message": "L'avis est validé et le document officiel de proposition est en cours de rédaction. Il résume votre situation et la recommandation de la préfecture au ministère.",
+    "message": "The opinion is validated and the official recommendation document is being drafted. It summarizes your situation and the prefecture's recommendation to the ministry.",
     "description": "Status full description for prop_decision_pref_prop_a_editer"
   },
   "status_prop_decision_pref_en_attente_retour_signataire_phase": {
-    "message": "Décision préfecture",
+    "message": "Prefecture decision",
     "description": "Status phase for prop_decision_pref_en_attente_retour_signataire"
   },
   "status_prop_decision_pref_en_attente_retour_signataire_explication": {
-    "message": "Attente signature du préfet",
+    "message": "Awaiting prefect's signature",
     "description": "Status explanation for prop_decision_pref_en_attente_retour_signataire"
   },
   "status_prop_decision_pref_en_attente_retour_signataire_description": {
-    "message": "Le document de proposition est finalisé et transmis au préfet (ou son représentant) pour signature. Une fois signé, votre dossier sera envoyé au ministère de l'Intérieur (SDANF).",
+    "message": "The recommendation document is finalized and sent to the prefect (or their representative) for signature. Once signed, your case will be sent to the Ministry of the Interior (SDANF).",
     "description": "Status full description for prop_decision_pref_en_attente_retour_signataire"
   },
   "status_controle_a_affecter_phase": {
-    "message": "Contrôle SDANF",
+    "message": "SDANF review",
     "description": "Status phase for controle_a_affecter"
   },
   "status_controle_a_affecter_explication": {
-    "message": "Arrivé à la SDANF, attente affectation",
+    "message": "Arrived at SDANF, awaiting assignment",
     "description": "Status explanation for controle_a_affecter"
   },
   "status_controle_a_affecter_description": {
-    "message": "Votre dossier est arrivé à la Sous-Direction de l'Accès à la Nationalité Française (SDANF) à Rezé (44). Il attend d'être attribué à un agent pour le contrôle ministériel.",
+    "message": "Your case has arrived at the Sub-Directorate for Access to French Nationality (SDANF) in Rez\u00e9 (44). It is waiting to be assigned to an officer for ministerial review.",
     "description": "Status full description for controle_a_affecter"
   },
   "status_controle_a_effectuer_phase": {
-    "message": "Contrôle SDANF",
+    "message": "SDANF review",
     "description": "Status phase for controle_a_effectuer"
   },
   "status_controle_a_effectuer_explication": {
-    "message": "Contrôle ministériel en cours",
+    "message": "Ministerial review in progress",
     "description": "Status explanation for controle_a_effectuer"
   },
   "status_controle_a_effectuer_description": {
-    "message": "Un agent de la SDANF contrôle votre dossier : vérification des pièces d'état civil, cohérence des informations, respect des conditions légales. Cette étape peut prendre plusieurs semaines.",
+    "message": "An SDANF officer is reviewing your case: verification of civil status documents, consistency of information, compliance with legal conditions. This step can take several weeks.",
     "description": "Status full description for controle_a_effectuer"
   },
   "status_controle_en_attente_pec_phase": {
-    "message": "Contrôle SCEC",
+    "message": "SCEC review",
     "description": "Status phase for controle_en_attente_pec"
   },
   "status_controle_en_attente_pec_explication": {
-    "message": "Transmis au SCEC de Nantes",
+    "message": "Sent to SCEC in Nantes",
     "description": "Status explanation for controle_en_attente_pec"
   },
   "status_controle_en_attente_pec_description": {
-    "message": "Le Service Central d'État Civil (SCEC) de Nantes vérifie l'authenticité de vos actes d'état civil étrangers. Cette vérification est obligatoire pour valider votre identité.",
+    "message": "The Central Civil Status Service (SCEC) in Nantes is verifying the authenticity of your foreign civil status documents. This verification is mandatory to validate your identity.",
     "description": "Status full description for controle_en_attente_pec"
   },
   "status_controle_pec_a_faire_phase": {
-    "message": "Contrôle SCEC",
+    "message": "SCEC review",
     "description": "Status phase for controle_pec_a_faire"
   },
   "status_controle_pec_a_faire_explication": {
-    "message": "Vérification d'état civil en cours",
+    "message": "Civil status verification in progress",
     "description": "Status explanation for controle_pec_a_faire"
   },
   "status_controle_pec_a_faire_description": {
-    "message": "Le SCEC procède à la vérification de vos pièces d'état civil. Une fois validées, vos actes seront transcrits dans les registres français si votre naturalisation aboutit.",
+    "message": "The SCEC is verifying your civil status documents. Once validated, your records will be transcribed into French registers if your naturalization is granted.",
     "description": "Status full description for controle_pec_a_faire"
   },
   "status_controle_transmise_pour_decret_phase": {
-    "message": "Préparation décret",
+    "message": "Decree preparation",
     "description": "Status phase for controle_transmise_pour_decret"
   },
   "status_controle_transmise_pour_decret_explication": {
-    "message": "Avis FAVORABLE, transmis pour décret",
+    "message": "FAVORABLE opinion, sent for decree",
     "description": "Status explanation for controle_transmise_pour_decret"
   },
   "status_controle_transmise_pour_decret_description": {
-    "message": "Excellente nouvelle ! L'avis est FAVORABLE. Votre dossier est transmis au service des décrets pour être inclus dans un prochain décret de naturalisation. La fin approche !",
+    "message": "Excellent news! The opinion is FAVORABLE. Your case has been sent to the decree department to be included in an upcoming naturalization decree. The end is near!",
     "description": "Status full description for controle_transmise_pour_decret"
   },
   "status_controle_en_attente_retour_hierarchique_phase": {
-    "message": "Préparation décret",
+    "message": "Decree preparation",
     "description": "Status phase for controle_en_attente_retour_hierarchique"
   },
   "status_controle_en_attente_retour_hierarchique_explication": {
-    "message": "Validation hiérarchique ministérielle",
+    "message": "Ministerial hierarchical validation",
     "description": "Status explanation for controle_en_attente_retour_hierarchique"
   },
   "status_controle_en_attente_retour_hierarchique_description": {
-    "message": "Le projet de décret incluant votre demande est soumis à la validation de la hiérarchie ministérielle. Étape administrative normale avant la finalisation du décret.",
+    "message": "The draft decree including your application is submitted for validation by the ministerial hierarchy. This is a normal administrative step before the decree is finalized.",
     "description": "Status full description for controle_en_attente_retour_hierarchique"
   },
   "status_controle_decision_a_editer_phase": {
-    "message": "Préparation décret",
+    "message": "Decree preparation",
     "description": "Status phase for controle_decision_a_editer"
   },
   "status_controle_decision_a_editer_explication": {
-    "message": "Décision favorable, édition en cours",
+    "message": "Favorable decision, being drafted",
     "description": "Status explanation for controle_decision_a_editer"
   },
   "status_controle_decision_a_editer_description": {
-    "message": "La décision favorable est confirmée. Le document officiel du décret incluant votre nom est en cours d'édition. Vous serez bientôt inscrit(e) dans un décret de naturalisation.",
+    "message": "The favorable decision is confirmed. The official decree document including your name is being drafted. You will soon be listed in a naturalization decree.",
     "description": "Status full description for controle_decision_a_editer"
   },
   "status_controle_en_attente_signature_phase": {
-    "message": "Préparation décret",
+    "message": "Decree preparation",
     "description": "Status phase for controle_en_attente_signature"
   },
   "status_controle_en_attente_signature_explication": {
-    "message": "Attente signature ministérielle",
+    "message": "Awaiting ministerial signature",
     "description": "Status explanation for controle_en_attente_signature"
   },
   "status_controle_en_attente_signature_description": {
-    "message": "Le décret de naturalisation est finalisé et attend la signature du ministre ou de son représentant. Une fois signé, il sera publié au Journal Officiel.",
+    "message": "The naturalization decree is finalized and awaiting the minister's or their representative's signature. Once signed, it will be published in the Official Journal.",
     "description": "Status full description for controle_en_attente_signature"
   },
   "status_transmis_a_ac_phase": {
-    "message": "Préparation décret",
+    "message": "Decree preparation",
     "description": "Status phase for transmis_a_ac"
   },
   "status_transmis_a_ac_explication": {
-    "message": "Transmis à l'administration centrale",
+    "message": "Sent to central administration",
     "description": "Status explanation for transmis_a_ac"
   },
   "status_transmis_a_ac_description": {
-    "message": "Votre dossier favorable est transmis à l'administration centrale chargée de préparer les décrets. Vous êtes dans la dernière ligne droite de la procédure !",
+    "message": "Your favorable case has been sent to the central administration in charge of preparing decrees. You are in the final stretch of the process!",
     "description": "Status full description for transmis_a_ac"
   },
   "status_a_verifier_avant_insertion_decret_phase": {
-    "message": "Préparation décret",
+    "message": "Decree preparation",
     "description": "Status phase for a_verifier_avant_insertion_decret"
   },
   "status_a_verifier_avant_insertion_decret_explication": {
-    "message": "Vérifications finales avant insertion",
+    "message": "Final checks before insertion",
     "description": "Status explanation for a_verifier_avant_insertion_decret"
   },
   "status_a_verifier_avant_insertion_decret_description": {
-    "message": "Dernières vérifications administratives aléatoires et facultatives avant l'insertion de votre nom dans un décret. On s'assure qu'aucun élément nouveau ne s'oppose à votre naturalisation.",
+    "message": "Final random and optional administrative checks before inserting your name in a decree. Ensuring no new element opposes your naturalization.",
     "description": "Status full description for a_verifier_avant_insertion_decret"
   },
   "status_prete_pour_insertion_decret_phase": {
-    "message": "Préparation décret",
+    "message": "Decree preparation",
     "description": "Status phase for prete_pour_insertion_decret"
   },
   "status_prete_pour_insertion_decret_explication": {
-    "message": "Validé, prêt pour insertion au décret",
+    "message": "Validated, ready for decree insertion",
     "description": "Status explanation for prete_pour_insertion_decret"
   },
   "status_prete_pour_insertion_decret_description": {
-    "message": "Votre dossier est validé et prêt pour être inséré dans le prochain décret de naturalisation. La décision favorable a été signée par le Ministre !",
+    "message": "Your case is validated and ready to be inserted in the next naturalization decree. The favorable decision has been signed by the Minister!",
     "description": "Status full description for prete_pour_insertion_decret"
   },
   "status_decret_en_preparation_phase": {
-    "message": "Préparation décret",
+    "message": "Decree preparation",
     "description": "Status phase for decret_en_preparation"
   },
   "status_decret_en_preparation_explication": {
-    "message": "Décret en cours de préparation",
+    "message": "Decree being prepared",
     "description": "Status explanation for decret_en_preparation"
   },
   "status_decret_en_preparation_description": {
-    "message": "Un décret de naturalisation incluant votre nom est en cours de préparation. Plusieurs dossiers sont regroupés dans chaque décret avant publication au Journal Officiel.",
+    "message": "A naturalization decree including your name is being prepared. Multiple cases are grouped in each decree before publication in the Official Journal.",
     "description": "Status full description for decret_en_preparation"
   },
   "status_decret_a_qualifier_phase": {
-    "message": "Préparation décret",
+    "message": "Decree preparation",
     "description": "Status phase for decret_a_qualifier"
   },
   "status_decret_a_qualifier_explication": {
-    "message": "Décret en cours de qualification",
+    "message": "Decree being classified",
     "description": "Status explanation for decret_a_qualifier"
   },
   "status_decret_a_qualifier_description": {
-    "message": "Le décret incluant votre nom est en phase de qualification : catégorisation et vérification du type de décret (naturalisation, réintégration, etc.) avant validation finale.",
+    "message": "The decree including your name is in the classification phase: categorization and verification of the decree type (naturalization, reinstatement, etc.) before final validation.",
     "description": "Status full description for decret_a_qualifier"
   },
   "status_decret_en_validation_phase": {
-    "message": "Préparation décret",
+    "message": "Decree preparation",
     "description": "Status phase for decret_en_validation"
   },
   "status_decret_en_validation_explication": {
-    "message": "Décret en validation finale",
+    "message": "Decree in final validation",
     "description": "Status explanation for decret_en_validation"
   },
   "status_decret_en_validation_description": {
-    "message": "Le décret de naturalisation est en cours de validation finale par les services compétents. Dernière étape administrative avant la signature et la publication.",
+    "message": "The naturalization decree is undergoing final validation by the relevant departments. This is the last administrative step before signature and publication.",
     "description": "Status full description for decret_en_validation"
   },
   "status_inseree_dans_decret_phase": {
-    "message": "Publication JO",
+    "message": "Official Journal publication",
     "description": "Status phase for inseree_dans_decret"
   },
   "status_inseree_dans_decret_explication": {
-    "message": "Inséré dans un décret signé",
+    "message": "Included in a signed decree",
     "description": "Status explanation for inseree_dans_decret"
   },
   "status_inseree_dans_decret_description": {
-    "message": "Votre nom est officiellement inscrit dans un décret de naturalisation ! Il attend maintenant la publication au Journal Officiel de la République Française.",
+    "message": "Your name is officially listed in a naturalization decree! It is now awaiting publication in the Official Journal of the French Republic.",
     "description": "Status full description for inseree_dans_decret"
   },
   "status_decret_envoye_prefecture_phase": {
-    "message": "Publication JO",
+    "message": "Official Journal publication",
     "description": "Status phase for decret_envoye_prefecture"
   },
   "status_decret_envoye_prefecture_explication": {
-    "message": "Décret envoyé à votre préfecture",
+    "message": "Decree sent to your prefecture",
     "description": "Status explanation for decret_envoye_prefecture"
   },
   "status_decret_envoye_prefecture_description": {
-    "message": "Le décret signé a été transmis à votre préfecture. Elle va vous convoquer pour la cérémonie d'accueil dans la citoyenneté française et la remise de votre décret.",
+    "message": "The signed decree has been sent to your prefecture. They will summon you for the citizenship welcome ceremony and the handover of your decree.",
     "description": "Status full description for decret_envoye_prefecture"
   },
   "status_notification_envoyee_phase": {
-    "message": "Publication JO",
+    "message": "Official Journal publication",
     "description": "Status phase for notification_envoyee"
   },
   "status_notification_envoyee_explication": {
-    "message": "Notification officielle envoyée",
+    "message": "Official notification sent",
     "description": "Status explanation for notification_envoyee"
   },
   "status_notification_envoyee_description": {
-    "message": "La notification officielle de votre naturalisation vous a été envoyée. Vous serez convoqué(e) à la cérémonie d'accueil dans la citoyenneté française.",
+    "message": "The official notification of your naturalization has been sent to you. You will be summoned to the citizenship welcome ceremony.",
     "description": "Status full description for notification_envoyee"
   },
   "status_decret_naturalisation_publie_phase": {
-    "message": "NATURALISÉ(E)",
+    "message": "NATURALIZED",
     "description": "Status phase for decret_naturalisation_publie"
   },
   "status_decret_naturalisation_publie_explication": {
-    "message": "Décret publié au Journal Officiel",
+    "message": "Decree published in the Official Journal",
     "description": "Status explanation for decret_naturalisation_publie"
   },
   "status_decret_naturalisation_publie_description": {
-    "message": "FÉLICITATIONS ! Votre décret de naturalisation est publié au Journal Officiel de la République Française. Vous êtes officiellement citoyen(ne) français(e) !",
+    "message": "CONGRATULATIONS! Your naturalization decree has been published in the Official Journal of the French Republic. You are officially a French citizen!",
     "description": "Status full description for decret_naturalisation_publie"
   },
   "status_decret_naturalisation_publie_jo_phase": {
-    "message": "NATURALISÉ(E)",
+    "message": "NATURALIZED",
     "description": "Status phase for decret_naturalisation_publie_jo"
   },
   "status_decret_naturalisation_publie_jo_explication": {
-    "message": "Décret publié au Journal Officiel",
+    "message": "Decree published in the Official Journal",
     "description": "Status explanation for decret_naturalisation_publie_jo"
   },
   "status_decret_naturalisation_publie_jo_description": {
-    "message": "FÉLICITATIONS ! Votre décret de naturalisation est publié au Journal Officiel. Vous êtes officiellement français(e) ! La préfecture vous convoquera pour la cérémonie.",
+    "message": "CONGRATULATIONS! Your naturalization decree has been published in the Official Journal. You are officially French! The prefecture will summon you for the ceremony.",
     "description": "Status full description for decret_naturalisation_publie_jo"
   },
   "status_decret_publie_phase": {
-    "message": "NATURALISÉ(E)",
+    "message": "NATURALIZED",
     "description": "Status phase for decret_publie"
   },
   "status_decret_publie_explication": {
-    "message": "Décret publié",
+    "message": "Decree published",
     "description": "Status explanation for decret_publie"
   },
   "status_decret_publie_description": {
-    "message": "FÉLICITATIONS ! Votre décret de naturalisation est publié. Vous êtes officiellement citoyen(ne) français(e) ! La préfecture vous convoquera pour la cérémonie d'accueil.",
+    "message": "CONGRATULATIONS! Your naturalization decree has been published. You are officially a French citizen! The prefecture will summon you for the welcome ceremony.",
     "description": "Status full description for decret_publie"
   },
   "status_demande_traitee_phase": {
-    "message": "Finalisé",
+    "message": "Finalized",
     "description": "Status phase for demande_traitee"
   },
   "status_demande_traitee_explication": {
-    "message": "Demande entièrement traitée",
+    "message": "Application fully processed",
     "description": "Status explanation for demande_traitee"
   },
   "status_demande_traitee_description": {
-    "message": "Votre demande de naturalisation a été entièrement traitée. Consultez vos courriers ou contactez votre préfecture pour connaître l'issue de votre dossier.",
+    "message": "Your naturalization application has been fully processed. Check your mail or contact your prefecture to learn the outcome of your case.",
     "description": "Status full description for demande_traitee"
   },
   "status_decision_negative_en_delais_recours_phase": {
-    "message": "Décision négative",
+    "message": "Negative decision",
     "description": "Status phase for decision_negative_en_delais_recours"
   },
   "status_decision_negative_en_delais_recours_explication": {
-    "message": "Défavorable, délai de recours ouvert",
+    "message": "Unfavorable, appeal period open",
     "description": "Status explanation for decision_negative_en_delais_recours"
   },
   "status_decision_negative_en_delais_recours_description": {
-    "message": "Votre demande a reçu une décision défavorable. Vous disposez d'un délai de 2 mois pour former un recours gracieux auprès du ministre (RAPO) ou un recours contentieux devant le tribunal administratif.",
+    "message": "Your application has received an unfavorable decision. You have 2 months to file a gracious appeal with the minister (RAPO) or a contentious appeal before the administrative court.",
     "description": "Status full description for decision_negative_en_delais_recours"
   },
   "status_decision_notifiee_phase": {
-    "message": "Décision négative",
+    "message": "Negative decision",
     "description": "Status phase for decision_notifiee"
   },
   "status_decision_notifiee_explication": {
-    "message": "Décision notifiée au demandeur",
+    "message": "Decision notified to applicant",
     "description": "Status explanation for decision_notifiee"
   },
   "status_decision_notifiee_description": {
-    "message": "La décision concernant votre dossier vous a été officiellement notifiée. Consultez le courrier pour connaître la nature de la décision et les voies de recours disponibles.",
+    "message": "The decision regarding your case has been officially notified. Check the letter to learn the nature of the decision and available appeal options.",
     "description": "Status full description for decision_notifiee"
   },
   "status_demande_en_cours_rapo_phase": {
-    "message": "Recours RAPO",
+    "message": "RAPO appeal",
     "description": "Status phase for demande_en_cours_rapo"
   },
   "status_demande_en_cours_rapo_explication": {
-    "message": "Recours administratif en cours",
+    "message": "Administrative appeal in progress",
     "description": "Status explanation for demande_en_cours_rapo"
   },
   "status_demande_en_cours_rapo_description": {
-    "message": "Votre recours administratif préalable obligatoire (RAPO) est en cours d'examen par le ministère. Le RAPO est un recours gracieux contre une décision défavorable. Délai de réponse : environ 4 mois.",
+    "message": "Your mandatory prior administrative appeal (RAPO) is being reviewed by the ministry. The RAPO is a gracious appeal against an unfavorable decision. Expected response time: approximately 4 months.",
     "description": "Status full description for demande_en_cours_rapo"
   },
   "status_controle_demande_notifiee_phase": {
-    "message": "Décision notifiée",
+    "message": "Decision notified",
     "description": "Status phase for controle_demande_notifiee"
   },
   "status_controle_demande_notifiee_explication": {
-    "message": "Décision de contrôle notifiée",
+    "message": "Review decision notified",
     "description": "Status explanation for controle_demande_notifiee"
   },
   "status_controle_demande_notifiee_description": {
-    "message": "La décision issue du contrôle ministériel vous a été officiellement communiquée. Vérifiez vos courriers pour connaître la suite donnée à votre dossier.",
+    "message": "The decision from the ministerial review has been officially communicated to you. Check your mail to learn the next steps for your case.",
     "description": "Status full description for controle_demande_notifiee"
   },
   "status_irrecevabilite_manifeste_phase": {
-    "message": "Irrecevabilité",
+    "message": "Inadmissibility",
     "description": "Status phase for irrecevabilite_manifeste"
   },
   "status_irrecevabilite_manifeste_explication": {
-    "message": "Conditions légales non remplies",
+    "message": "Legal conditions not met",
     "description": "Status explanation for irrecevabilite_manifeste"
   },
   "status_irrecevabilite_manifeste_description": {
-    "message": "Votre demande ne remplit pas les conditions légales de recevabilité (durée de résidence, titre de séjour, etc.). Vérifiez les critères d'éligibilité avant de déposer une nouvelle demande.",
+    "message": "Your application does not meet the legal admissibility conditions (length of residence, residence permit, etc.). Check the eligibility criteria before filing a new application.",
     "description": "Status full description for irrecevabilite_manifeste"
   },
   "status_irrecevabilite_manifeste_en_delais_recours_phase": {
-    "message": "Irrecevabilité",
+    "message": "Inadmissibility",
     "description": "Status phase for irrecevabilite_manifeste_en_delais_recours"
   },
   "status_irrecevabilite_manifeste_en_delais_recours_explication": {
-    "message": "Irrecevable, délai de recours ouvert",
+    "message": "Inadmissible, appeal period open",
     "description": "Status explanation for irrecevabilite_manifeste_en_delais_recours"
   },
   "status_irrecevabilite_manifeste_en_delais_recours_description": {
-    "message": "Votre demande a été déclarée irrecevable. Vous pouvez contester cette décision par un recours gracieux (RAPO) ou contentieux dans un délai de 2 mois.",
+    "message": "Your application has been declared inadmissible. You may contest this decision through a gracious appeal (RAPO) or a contentious appeal within 2 months.",
     "description": "Status full description for irrecevabilite_manifeste_en_delais_recours"
   },
   "status_css_en_delais_recours_phase": {
-    "message": "Classement sans suite",
+    "message": "Case closed",
     "description": "Status phase for css_en_delais_recours"
   },
   "status_css_en_delais_recours_explication": {
-    "message": "Classé sans suite, recours possible",
+    "message": "Closed without action, appeal possible",
     "description": "Status explanation for css_en_delais_recours"
   },
   "status_css_en_delais_recours_description": {
-    "message": "Votre dossier a été classé sans suite (pièces non fournies dans les délais, désistement, etc.). Vous pouvez former un recours ou déposer une nouvelle demande complète.",
+    "message": "Your case has been closed without action (documents not provided on time, withdrawal, etc.). You may file an appeal or submit a new complete application.",
     "description": "Status full description for css_en_delais_recours"
   },
   "status_css_notifie_phase": {
-    "message": "Classement sans suite",
+    "message": "Case closed",
     "description": "Status phase for css_notifie"
   },
   "status_css_notifie_explication": {
-    "message": "Classement sans suite notifié",
+    "message": "Case closure notified",
     "description": "Status explanation for css_notifie"
   },
   "status_css_notifie_description": {
-    "message": "Le classement sans suite de votre dossier vous a été officiellement notifié. Analysez les motifs indiqués avant d'envisager une nouvelle demande.",
+    "message": "The closure of your case has been officially notified. Review the stated reasons before considering a new application.",
     "description": "Status full description for css_notifie"
   },
 
   "status_unknown_phase": {
-    "message": "Statut inconnu",
+    "message": "Unknown status",
     "description": "Fallback phase for unrecognized status"
   },
   "status_unknown_explication": {
-    "message": "Non disponible",
+    "message": "Not available",
     "description": "Fallback explanation for unrecognized status"
   },
   "status_unknown_description": {
-    "message": "Statut non répertorié. Contactez votre préfecture.",
+    "message": "Unrecognized status. Contact your prefecture.",
     "description": "Fallback description for unrecognized status"
   },
 
   "step_dossier_depose_label": {
-    "message": "Dépôt du dossier",
+    "message": "Case filing",
     "description": "Step default label for dossier_depose"
   },
   "step_ea_en_attente_ea_label": {
-    "message": "Entretien d'assimilation",
+    "message": "Assimilation interview",
     "description": "Step default label for ea_en_attente_ea"
   },
   "step_controle_a_affecter_label": {
-    "message": "SDANF — Attente affectation",
+    "message": "SDANF \u2014 Awaiting assignment",
     "description": "Step default label for controle_a_affecter"
   },
   "step_controle_a_effectuer_label": {
-    "message": "SDANF — Contrôle en cours",
+    "message": "SDANF \u2014 Review in progress",
     "description": "Step default label for controle_a_effectuer"
   },
   "step_controle_en_attente_pec_label": {
-    "message": "SCEC — Transmis Nantes",
+    "message": "SCEC \u2014 Sent to Nantes",
     "description": "Step default label for controle_en_attente_pec"
   },
   "step_prete_pour_insertion_decret_label": {
-    "message": "PPID — Prêt pour insertion décret",
+    "message": "PPID \u2014 Ready for decree insertion",
     "description": "Step default label for prete_pour_insertion_decret"
   },
   "step_inseree_dans_decret_label": {
-    "message": "IDD — Inséré dans le décret",
+    "message": "IDD \u2014 Inserted in decree",
     "description": "Step default label for inseree_dans_decret"
   },
   "step_decret_naturalisation_publie_label": {
-    "message": "Publication au JO",
+    "message": "Official Journal publication",
     "description": "Step default label for decret_naturalisation_publie"
   }
 }

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -12,6 +12,7 @@ import * as storage from '../lib/storage.js';
 import { getStatusExplanation, isPositiveStatus, isNegativeStatus, getStepColor, formatTimestamp, formatSubStep } from '../lib/status-parser.js';
 import { ANEF_BASE_URL, ANEF_ROUTES, URLPatterns, LogConfig } from '../lib/constants.js';
 import { sendAnonymousStats, sendManualStepDates, fetchDossierSnapshots } from '../lib/anonymous-stats.js';
+import { t } from '../lib/i18n-helper.js';
 
 // ─────────────────────────────────────────────────────────────
 // Configuration
@@ -81,7 +82,7 @@ async function cleanupOrphanedWindow() {
     if (savedWindowId) {
       try {
         await chrome.windows.remove(savedWindowId);
-        logger.info('🗑️ Fenêtre orpheline fermée:', savedWindowId);
+        logger.info('🗑️ Orphaned window closed:', savedWindowId);
       } catch {
         // Fenêtre déjà fermée, ok
       }
@@ -99,7 +100,7 @@ cleanupOrphanedWindow();
 // ─────────────────────────────────────────────────────────────
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  logger.debug('Message reçu:', { type: message.type, from: sender.tab?.url || 'popup' });
+  logger.debug('Message received:', { type: message.type, from: sender.tab?.url || 'popup' });
 
   switch (message.type) {
     // Logs du content script
@@ -115,44 +116,44 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     // Données du dossier (statut principal)
     case 'DOSSIER_DATA':
-      logger.info('📥 Données dossier reçues', message.data);
+      logger.info('📥 Dossier data received', message.data);
       handleDossierData(message.data);
       sendResponse({ received: true });
       break;
 
     // Données du stepper (ID dossier)
     case 'DOSSIER_STEPPER':
-      logger.info('📥 Stepper reçu', { id: message.data?.dossier?.id });
+      logger.info('📥 Stepper received', { id: message.data?.dossier?.id });
       handleDossierStepper(message.data);
       break;
 
     // Données détaillées de l'API
     case 'API_DATA':
-      logger.info('📥 Données API reçues');
+      logger.info('📥 API data received');
       handleApiData(message.data);
       break;
 
     // Notifications ANEF
     case 'NOTIFICATIONS':
-      logger.info('📥 Notifications reçues', { count: message.data?.length });
+      logger.info('📥 Notifications received', { count: message.data?.length });
       handleNotifications(message.data);
       break;
 
     // Informations utilisateur
     case 'USER_INFO':
-      logger.info('📥 Infos utilisateur reçues', message.data);
+      logger.info('📥 User info received', message.data);
       handleUserInfo(message.data);
       break;
 
     // Historique des séjours
     case 'HISTORIQUE':
-      logger.info('📥 Historique reçu', message.data);
+      logger.info('📥 History received', message.data);
       handleHistorique(message.data);
       break;
 
     // Page chargée
     case 'PAGE_READY':
-      logger.info('📄 Page prête', message);
+      logger.info('📄 Page ready', message);
       break;
 
     // Navigation SPA
@@ -162,19 +163,19 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     // Site en maintenance
     case 'MAINTENANCE':
-      logger.warn('🔧 Maintenance détectée');
+      logger.warn('🔧 Maintenance detected');
       handleMaintenance();
       break;
 
     // Session expirée (JWT invalide / mot de passe expiré)
     case 'EXPIRED_SESSION':
-      logger.warn('🔑 Session expirée détectée (JWT invalide)');
+      logger.warn('🔑 Expired session detected (invalid JWT)');
       handleExpiredSession();
       break;
 
     // Résultat de la récupération par le script injecté
     case 'FETCH_COMPLETE':
-      logger.info('📥 Fetch terminé:', message.data);
+      logger.info('📥 Fetch complete:', message.data);
       handleFetchComplete(message.data);
       break;
 
@@ -209,7 +210,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     // Actualisation en arrière-plan
     case 'BACKGROUND_REFRESH': {
-      logger.info('🔄 Actualisation manuelle demandée');
+      logger.info('🔄 Manual refresh requested');
       const manualStart = Date.now();
       refreshPromise = backgroundRefresh();
       refreshPromise.then(async (result) => {
@@ -240,7 +241,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     // Paramètres modifiés → reconfigurer l'alarme auto-check
     case 'SETTINGS_CHANGED':
-      logger.info('⚙️ Paramètres modifiés, reconfiguration auto-check');
+      logger.info('⚙️ Settings changed, reconfiguring auto-check');
       scheduleAutoCheck().then(() => sendResponse({ ok: true }));
       return true;
 
@@ -259,7 +260,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             await sendManualStepDates(stepDates, apiData);
             sendResponse({ success: true });
           } else {
-            sendResponse({ success: false, error: 'Pas de données' });
+            sendResponse({ success: false, error: 'No data' });
           }
         } catch (e) {
           sendResponse({ success: false, error: e.message });
@@ -273,7 +274,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         try {
           const apiData = await storage.getApiData();
           if (!apiData?.dossierId) {
-            sendResponse({ error: 'Aucun dossier connu' });
+            sendResponse({ error: 'No known dossier' });
             return;
           }
           const snapshots = await fetchDossierSnapshots(apiData);
@@ -326,7 +327,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       return true;
 
     default:
-      logger.warn('Message non géré:', message.type);
+      logger.warn('Unhandled message:', message.type);
   }
 });
 
@@ -337,7 +338,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 /** Traite les données du dossier (statut principal) */
 async function handleDossierData(data) {
   if (!data?.statut) {
-    logger.warn('Données invalides - pas de statut');
+    logger.warn('Invalid data - no status');
     return;
   }
 
@@ -353,17 +354,17 @@ async function handleDossierData(data) {
     // Vérifier si le statut a changé
     const hasChanged = await storage.hasStatusChanged(data);
     if (hasChanged) {
-      logger.info('🔔 Changement de statut détecté !', { nouveau: data.statut });
+      logger.info('🔔 Status change detected!', { new: data.statut });
       await sendStatusChangeNotification(data);
     }
 
     // Sauvegarder et mettre à jour le badge
     await storage.saveStatus(data);
     await updateBadge(data.statut);
-    logger.info('✅ Statut sauvegardé');
+    logger.info('✅ Status saved');
 
   } catch (error) {
-    logger.error('Erreur traitement dossier:', error.message);
+    logger.error('Error processing dossier:', error.message);
   }
 }
 
@@ -396,7 +397,7 @@ async function handleApiData(data) {
   };
 
   await storage.saveApiData(apiData);
-  logger.info('✅ Données API sauvegardées');
+  logger.info('✅ API data saved');
 
   // Statistiques anonymes communautaires (fire-and-forget)
   const lastStatus = await storage.getLastStatus();
@@ -477,12 +478,12 @@ async function sendStatusChangeNotification(data) {
   if (!settings.notificationsEnabled) return;
 
   const statusInfo = getStatusExplanation(data.statut);
-  let title = '🔔 Changement de statut ANEF !';
+  let title = '🔔 ' + t('notification_status_change');
 
   if (isPositiveStatus(data.statut)) {
-    title = '🎉 FÉLICITATIONS !';
+    title = '🎉 ' + t('notification_congratulations');
   } else if (isNegativeStatus(data.statut)) {
-    title = '⚠️ Mise à jour de votre dossier';
+    title = '⚠️ ' + t('notification_update');
   }
 
   try {
@@ -495,7 +496,7 @@ async function sendStatusChangeNotification(data) {
       requireInteraction: true
     });
   } catch (error) {
-    logger.error('Erreur notification:', error.message);
+    logger.error('Notification error:', error.message);
   }
 }
 
@@ -520,7 +521,7 @@ async function updateBadge(statut) {
         : 'ANEF Status Tracker'
     });
   } catch (error) {
-    logger.error('Erreur badge:', error.message);
+    logger.error('Badge error:', error.message);
   }
 }
 
@@ -563,7 +564,7 @@ async function openAnefPage(page) {
   try {
     await chrome.tabs.create({ url, active: true });
   } catch (error) {
-    logger.error('Erreur ouverture onglet:', error.message);
+    logger.error('Error opening tab:', error.message);
   }
 }
 
@@ -613,7 +614,7 @@ function abortableSleep(ms, signal) {
 async function backgroundRefresh() {
   // Si une actualisation est déjà en cours, l'annuler et attendre son nettoyage
   if (isRefreshing && refreshAbortController) {
-    logger.warn('⚠️ Actualisation déjà en cours → annulation de l\'ancienne');
+    logger.warn('⚠️ Refresh already in progress → cancelling previous');
     refreshAbortController.abort();
     if (refreshPromise) {
       try { await refreshPromise; } catch {}
@@ -623,7 +624,7 @@ async function backgroundRefresh() {
   const abortController = new AbortController();
   refreshAbortController = abortController;
   isRefreshing = true;
-  logger.info('🔄 Démarrage actualisation...');
+  logger.info('🔄 Starting refresh...');
 
   // Configuration des délais
   const TIMEOUT_MS = 45000;       // Timeout sans login
@@ -679,14 +680,14 @@ async function backgroundRefresh() {
 
       // Naviguer vers l'URL après que la fenêtre soit minimisée
       await chrome.tabs.update(tabId, { url: MON_COMPTE_URL });
-      logger.info('✅ Fenêtre minimisée créée:', { windowId, tabId });
+      logger.info('✅ Minimized window created:', { windowId, tabId });
     } catch (winErr) {
       // Fallback: onglet inactif (si windows.create échoue, ex: ChromeOS)
-      logger.warn('Fenêtre impossible:', winErr.message);
+      logger.warn('Window creation failed:', winErr.message);
       const tab = await chrome.tabs.create({ url: MON_COMPTE_URL, active: false });
       tabId = tab.id;
       useWindow = false;
-      logger.info('✅ Onglet inactif créé:', { tabId });
+      logger.info('✅ Inactive tab created:', { tabId });
     }
 
     // ── Boucle d'attente des données ──
@@ -700,7 +701,7 @@ async function backgroundRefresh() {
 
       // Vérifier si cette actualisation a été annulée par une nouvelle
       if (abortController.signal.aborted) {
-        logger.info('🛑 Actualisation annulée (nouvelle demandée)');
+        logger.info('🛑 Refresh cancelled (new one requested)');
         break;
       }
 
@@ -709,7 +710,7 @@ async function backgroundRefresh() {
       try {
         tabInfo = await chrome.tabs.get(tabId);
       } catch {
-        logger.warn('Onglet fermé prématurément');
+        logger.warn('Tab closed prematurely');
         break;
       }
 
@@ -727,19 +728,19 @@ async function backgroundRefresh() {
 
         // Si on arrive sur la page d'accueil après login, naviguer vers mon-compte
         if (isOnHomepage && (loginAttempted.anef || loginAttempted.sso) && !loginCompleted) {
-          logger.info('🏠 Page d\'accueil détectée après login, navigation vers mon-compte...');
+          logger.info('🏠 Homepage detected after login, navigating to mon-compte...');
           try {
             await chrome.tabs.update(tabId, { url: MON_COMPTE_URL });
-            logger.info('📤 Navigation vers mon-compte lancée');
+            logger.info('📤 Navigation to mon-compte started');
           } catch (e) {
-            logger.warn('Erreur navigation:', e.message);
+            logger.warn('Navigation error:', e.message);
           }
           lastUrl = currentUrl;
           continue;
         }
 
         if (isOnMonCompte && (loginAttempted.anef || loginAttempted.sso)) {
-          logger.info('✅ Connexion réussie, arrivé sur mon-compte');
+          logger.info('✅ Login successful, arrived at mon-compte');
           loginCompleted = true;
           fetchCompleteSignal = null; // Attendre un nouveau signal post-login
           // Attendre que Angular charge la page
@@ -748,9 +749,9 @@ async function backgroundRefresh() {
           // Déclencher explicitement la récupération des données
           try {
             await chrome.tabs.sendMessage(tabId, { type: 'TRIGGER_DATA_FETCH' });
-            logger.info('📤 Demande de récupération envoyée');
+            logger.info('📤 Data fetch request sent');
           } catch (e) {
-            logger.warn('Erreur envoi TRIGGER_DATA_FETCH:', e.message);
+            logger.warn('Error sending TRIGGER_DATA_FETCH:', e.message);
           }
         }
 
@@ -764,7 +765,7 @@ async function backgroundRefresh() {
 
         // Page de changement de mot de passe (expiré)
         if (URLPatterns.isPasswordExpired(currentUrl)) {
-          logger.warn('🔑 Mot de passe ANEF expiré détecté');
+          logger.warn('🔑 ANEF expired password detected');
           const apiData = await storage.getApiData() || {};
           apiData.passwordExpired = true;
           await storage.saveApiData(apiData);
@@ -773,7 +774,7 @@ async function backgroundRefresh() {
 
         // Page de connexion ANEF détectée
         if (isAnefLogin && !loginAttempted.anef && hasCredentials) {
-          logger.info('🔐 Page connexion ANEF détectée');
+          logger.info('🔐 ANEF login page detected');
           needsLogin = true;
           loginAttempted.anef = true;
           fetchCompleteSignal = null; // Signal pré-login obsolète
@@ -787,9 +788,9 @@ async function backgroundRefresh() {
               type: 'DO_AUTO_LOGIN',
               credentials
             });
-            logger.info('📤 Auto-login ANEF envoyé');
+            logger.info('📤 ANEF auto-login sent');
           } catch (e) {
-            logger.warn('Erreur auto-login ANEF:', e.message);
+            logger.warn('ANEF auto-login error:', e.message);
           }
 
           // Attendre la redirection vers SSO
@@ -799,7 +800,7 @@ async function backgroundRefresh() {
 
         // Page SSO détectée
         if (isSSOPage && !loginAttempted.sso && hasCredentials) {
-          logger.info('🔐 Page SSO détectée');
+          logger.info('🔐 SSO page detected');
           loginAttempted.sso = true;
           fetchCompleteSignal = null; // Signal pré-login obsolète
 
@@ -812,9 +813,9 @@ async function backgroundRefresh() {
               type: 'DO_AUTO_LOGIN',
               credentials
             });
-            logger.info('📤 Auto-login SSO envoyé');
+            logger.info('📤 SSO auto-login sent');
           } catch (e) {
-            logger.warn('Erreur auto-login SSO:', e.message);
+            logger.warn('SSO auto-login error:', e.message);
           }
 
           // Attendre la soumission et redirection
@@ -824,7 +825,7 @@ async function backgroundRefresh() {
 
         // Session expirée sans identifiants
         if (isAnefLogin && !hasCredentials && elapsed > 10000) {
-          logger.warn('🔒 Session expirée, pas d\'identifiants');
+          logger.warn('🔒 Session expired, no credentials');
           needsLogin = true;
           break;
         }
@@ -833,7 +834,7 @@ async function backgroundRefresh() {
       // Vérifier si le script injecté a terminé (succès ou échec)
       if (fetchCompleteSignal && fetchCompleteSignal.timestamp > startTime) {
         if (!fetchCompleteSignal.success) {
-          logger.warn('⚠️ Script injecté a échoué:', fetchCompleteSignal.reason);
+          logger.warn('⚠️ Injected script failed:', fetchCompleteSignal.reason);
           // Si maintenance ou session expirée, sortir immédiatement
           if (fetchCompleteSignal.reason === 'maintenance' || fetchCompleteSignal.reason === 'expired_session') {
             break;
@@ -855,7 +856,7 @@ async function backgroundRefresh() {
       if (currentApiData?.inMaintenance && currentApiData?.maintenanceDetectedAt) {
         const detectedAt = new Date(currentApiData.maintenanceDetectedAt).getTime();
         if (detectedAt > startTime) {
-          logger.warn('🔧 Maintenance détectée pendant le refresh, arrêt');
+          logger.warn('🔧 Maintenance detected during refresh, stopping');
           break;
         }
       }
@@ -864,7 +865,7 @@ async function backgroundRefresh() {
       const currentCheck = await storage.getLastCheck();
       if (currentCheck && (!beforeCheck || currentCheck > beforeCheck)) {
         if (!dossierReceived) {
-          logger.info('✅ Données dossier reçues !');
+          logger.info('✅ Dossier data received!');
           dossierReceived = true;
           dossierTime = Date.now();
         }
@@ -874,13 +875,13 @@ async function backgroundRefresh() {
       if (dossierReceived) {
         const currentApiUpdate = (await storage.getApiData())?.lastUpdate;
         if (currentApiUpdate && (!beforeApiUpdate || currentApiUpdate > beforeApiUpdate)) {
-          logger.info('✅ Données API reçues !');
+          logger.info('✅ API data received!');
           dataReceived = true;
           break;
         }
         // Timeout pour les données API (8 secondes au lieu de 5)
         if (Date.now() - dossierTime > 8000) {
-          logger.info('⏱️ Timeout données API, on continue avec les données dossier');
+          logger.info('⏱️ API data timeout, continuing with dossier data');
           dataReceived = true;
           break;
         }
@@ -891,24 +892,24 @@ async function backgroundRefresh() {
     if (useWindow && windowId) {
       try {
         await chrome.windows.remove(windowId);
-        logger.info('🗑️ Fenêtre fermée');
+        logger.info('🗑️ Window closed');
       } catch {}
       await chrome.storage.local.remove(REFRESH_WINDOW_KEY).catch(() => {});
     } else if (tabId) {
       try {
         await chrome.tabs.remove(tabId);
-        logger.info('🗑️ Onglet fermé');
+        logger.info('🗑️ Tab closed');
       } catch {}
     }
 
     // Si annulée par une nouvelle actualisation, sortir sans résultat d'erreur
     if (abortController.signal.aborted) {
-      return { success: false, aborted: true, error: 'Annulée (nouvelle actualisation demandée)' };
+      return { success: false, aborted: true, error: 'Cancelled (new refresh requested)' };
     }
 
     // ── Résultat ──
     if (dataReceived) {
-      logger.info('✅ Actualisation réussie');
+      logger.info('✅ Refresh successful');
       return { success: true };
     }
 
@@ -917,13 +918,13 @@ async function backgroundRefresh() {
     if (finalApiData?.inMaintenance && finalApiData?.maintenanceDetectedAt) {
       const detectedAt = new Date(finalApiData.maintenanceDetectedAt).getTime();
       if (detectedAt > startTime) {
-        return { success: false, error: 'Site ANEF en maintenance. Réessayez plus tard.', maintenance: true };
+        return { success: false, error: 'ANEF site under maintenance. Try again later.', maintenance: true };
       }
     }
 
     // Mot de passe expiré
     if (finalApiData?.passwordExpired) {
-      return { success: false, error: 'Votre mot de passe ANEF a expiré. Renouvelez-le sur le portail ANEF.', passwordExpired: true };
+      return { success: false, error: 'Your ANEF password has expired. Renew it on the ANEF portal.', passwordExpired: true };
     }
 
     if (needsLogin && !hasCredentials) {
@@ -931,17 +932,17 @@ async function backgroundRefresh() {
     }
 
     if ((loginAttempted.anef || loginAttempted.sso) && !loginCompleted) {
-      return { success: false, error: 'Connexion tentée mais échec. Vérifiez vos identifiants.' };
+      return { success: false, error: 'Login attempted but failed. Check your credentials.' };
     }
 
     if (loginCompleted && !dataReceived) {
-      return { success: false, error: 'Connexion réussie mais données non récupérées. Réessayez.' };
+      return { success: false, error: 'Login successful but data not retrieved. Try again.' };
     }
 
-    return { success: false, error: 'Délai dépassé - pas de données reçues.' };
+    return { success: false, error: 'Timeout - no data received.' };
 
   } catch (error) {
-    logger.error('Erreur actualisation:', error.message);
+    logger.error('Refresh error:', error.message);
 
     if (useWindow && windowId) {
       try { await chrome.windows.remove(windowId); } catch {}
@@ -981,7 +982,7 @@ async function scheduleAutoCheck() {
   await chrome.alarms.clear(ALARM_RETRY_NAME);
 
   if (!settings.autoCheckEnabled || !hasCreds) {
-    logger.info('⏹️ Auto-check désactivé', {
+    logger.info('⏹️ Auto-check disabled', {
       enabled: settings.autoCheckEnabled,
       creds: hasCreds
     });
@@ -1006,16 +1007,16 @@ async function scheduleAutoCheck() {
     if (elapsedMin >= intervalMinutes) {
       // En retard (PC éteint, navigateur fermé...) → check rapide avec petit jitter
       delayMinutes = Math.floor(Math.random() * 3) + 1; // 1-3 min
-      delayReason = `en retard de ${Math.round(elapsedMin - intervalMinutes)} min`;
+      delayReason = `overdue by ${Math.round(elapsedMin - intervalMinutes)} min`;
     } else {
       // Pas encore l'heure → attendre le temps restant
       delayMinutes = Math.max(1, Math.round(intervalMinutes - elapsedMin));
-      delayReason = `temps restant du cycle`;
+      delayReason = `remaining cycle time`;
     }
   } else {
     // Jamais vérifié → délai normal avec jitter
     delayMinutes = jitter + 1;
-    delayReason = 'première vérification';
+    delayReason = 'first check';
   }
 
   await chrome.alarms.create(ALARM_NAME, {
@@ -1023,10 +1024,10 @@ async function scheduleAutoCheck() {
     periodInMinutes: intervalMinutes
   });
 
-  logger.info('⏰ Auto-check programmé', {
-    interval: intervalMinutes + ' min' + (failures > 0 ? ` (backoff x${backoffMultiplier.toFixed(1)}, ${failures} échec(s))` : ''),
+  logger.info('⏰ Auto-check scheduled', {
+    interval: intervalMinutes + ' min' + (failures > 0 ? ` (backoff x${backoffMultiplier.toFixed(1)}, ${failures} failure(s))` : ''),
     firstIn: delayMinutes + ' min',
-    raison: delayReason
+    reason: delayReason
   });
 }
 
@@ -1037,19 +1038,19 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name !== ALARM_NAME && alarm.name !== ALARM_RETRY_NAME) return;
 
   const isRetry = alarm.name === ALARM_RETRY_NAME;
-  logger.info(`⏰ Alarme déclenchée: ${alarm.name}${isRetry ? ' (retry)' : ''}`);
+  logger.info(`⏰ Alarm triggered: ${alarm.name}${isRetry ? ' (retry)' : ''}`);
 
   try {
     // Vérifier les prérequis
     const settings = await storage.getSettings();
     if (!settings.autoCheckEnabled) {
-      logger.info('⏹️ Auto-check désactivé, skip');
+      logger.info('⏹️ Auto-check disabled, skip');
       return;
     }
 
     const hasCreds = await storage.hasCredentials();
     if (!hasCreds) {
-      logger.warn('⚠️ Pas d\'identifiants, skip auto-check');
+      logger.warn('⚠️ No credentials, skip auto-check');
       return;
     }
 
@@ -1060,14 +1061,14 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
       const cooldownMs = COOLDOWN_MINUTES * 60 * 1000;
       if (elapsed < cooldownMs) {
         const remaining = Math.round((cooldownMs - elapsed) / 60000);
-        logger.info(`⏳ Cooldown actif, skip (encore ${remaining} min)`);
+        logger.info(`⏳ Cooldown active, skip (${remaining} min remaining)`);
         return;
       }
     }
 
     // Vérifier qu'un refresh n'est pas déjà en cours
     if (isRefreshing) {
-      logger.warn('⚠️ Refresh déjà en cours, skip auto-check');
+      logger.warn('⚠️ Refresh already in progress, skip auto-check');
       return;
     }
 
@@ -1098,26 +1099,26 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
     if (result.success) {
       // Succès → reset compteur d'échecs
       await storage.saveAutoCheckMeta({ consecutiveFailures: 0 });
-      logger.info(`✅ Auto-check réussi (${durationSec}s)`);
+      logger.info(`✅ Auto-check successful (${durationSec}s)`);
     } else if (result.maintenance) {
       // Maintenance → ne pas compter comme un échec (pas la faute de l'utilisateur)
-      logger.info('🔧 Site en maintenance, ne compte pas comme échec');
+      logger.info('🔧 Site under maintenance, not counted as failure');
     } else if (result.passwordExpired) {
       // Mot de passe expiré → ne pas compter comme échec, pas la faute du système
-      logger.warn('🔑 Mot de passe expiré, ne compte pas comme échec');
+      logger.warn('🔑 Password expired, not counted as failure');
     } else if (result.needsLogin) {
       // Session expirée sans identifiants → ne pas compter comme échec
-      logger.info('🔒 Session expirée, identifiants requis');
+      logger.info('🔒 Session expired, credentials required');
     } else if (result.aborted) {
       // Annulé par un refresh manuel → ne pas compter comme échec
-      logger.info('🛑 Auto-check annulé par refresh manuel');
+      logger.info('🛑 Auto-check cancelled by manual refresh');
     } else {
       // Échec
-      await handleAutoCheckFailure(result.error || 'Échec inconnu', isRetry);
+      await handleAutoCheckFailure(result.error || 'Unknown failure', isRetry);
     }
 
   } catch (error) {
-    logger.error('❌ Erreur auto-check:', error.message);
+    logger.error('❌ Auto-check error:', error.message);
     await storage.addCheckLogEntry({
       type: isRetry ? 'retry' : 'auto',
       success: false,
@@ -1140,7 +1141,7 @@ async function handleAutoCheckFailure(reason, isRetry) {
 
   const failures = isRetry ? (meta.consecutiveFailures || 0) : (meta.consecutiveFailures || 0) + 1;
 
-  logger.warn(`⚠️ Auto-check échoué (${failures})`, { reason, isRetry });
+  logger.warn(`⚠️ Auto-check failed (${failures})`, { reason, isRetry });
 
   if (!isRetry) {
     await storage.saveAutoCheckMeta({ consecutiveFailures: failures });
@@ -1156,13 +1157,13 @@ async function handleAutoCheckFailure(reason, isRetry) {
       delayInMinutes: intervalMinutes,
       periodInMinutes: intervalMinutes
     });
-    logger.info('⏰ Auto-check reprogrammé', {
+    logger.info('⏰ Auto-check rescheduled', {
       interval: intervalMinutes + ' min',
-      backoff: `x${backoffMultiplier.toFixed(1)} (${failures} échec(s))`
+      backoff: `x${backoffMultiplier.toFixed(1)} (${failures} failure(s))`
     });
     // Planifier un retry à +30 min
     await chrome.alarms.create(ALARM_RETRY_NAME, { delayInMinutes: 30 });
-    logger.info('🔄 Retry programmé dans 30 min');
+    logger.info('🔄 Retry scheduled in 30 min');
   }
 }
 
@@ -1196,18 +1197,18 @@ async function getAutoCheckInfo() {
 // ─────────────────────────────────────────────────────────────
 
 chrome.runtime.onInstalled.addListener(async (details) => {
-  logger.info('🚀 Extension installée:', details.reason);
+  logger.info('🚀 Extension installed:', details.reason);
 
   if (details.reason === 'install') {
     // Générer un jitter aléatoire unique pour cette installation (0-60 min)
     const jitter = Math.floor(Math.random() * 60);
     await storage.saveSettings({ ...storage.DEFAULT_SETTINGS, autoCheckJitterMin: jitter });
-    logger.info('🎲 Jitter auto-check généré:', jitter + ' min');
+    logger.info('🎲 Auto-check jitter generated:', jitter + ' min');
 
     // Tenter de restaurer l'historique depuis sync (migration ou nouveau dossier)
     const restored = await storage.restoreFromSync();
     if (restored) {
-      logger.info('✅ Données restaurées depuis sync');
+      logger.info('✅ Data restored from sync');
       const lastStatus = await storage.getLastStatus();
       if (lastStatus?.statut) await updateBadge(lastStatus.statut);
     }
@@ -1219,7 +1220,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
     // (ne pas forcer si l'utilisateur l'a volontairement désactivé)
     if (!currentSettings.autoCheckEnabled && !currentSettings._autoCheckMigrated) {
       await storage.saveSettings({ autoCheckEnabled: true, _autoCheckMigrated: true });
-      logger.info('✅ Auto-check activé (migration initiale)');
+      logger.info('✅ Auto-check enabled (initial migration)');
     } else if (!currentSettings._autoCheckMigrated) {
       await storage.saveSettings({ _autoCheckMigrated: true });
     }
@@ -1227,12 +1228,12 @@ chrome.runtime.onInstalled.addListener(async (details) => {
     if (!currentSettings.autoCheckJitterMin) {
       const jitter = Math.floor(Math.random() * 60);
       await storage.saveSettings({ autoCheckJitterMin: jitter });
-      logger.info('🎲 Jitter auto-check généré (migration):', jitter + ' min');
+      logger.info('🎲 Auto-check jitter generated (migration):', jitter + ' min');
     }
     // Migration : forcer l'intervalle à 90 min
     if (currentSettings.autoCheckInterval !== 90) {
       await storage.saveSettings({ autoCheckInterval: 90 });
-      logger.info('⏰ Intervalle auto-check corrigé:', currentSettings.autoCheckInterval, '→ 90 min');
+      logger.info('⏰ Auto-check interval corrected:', currentSettings.autoCheckInterval, '→ 90 min');
     }
     // Migration v2.2.0 : supprimer disabledByFailure obsolète, reset compteur
     const meta = await storage.getAutoCheckMeta();
@@ -1244,15 +1245,15 @@ chrome.runtime.onInstalled.addListener(async (details) => {
           consecutiveFailures: 0
         }
       });
-      logger.info('🔄 Migration: disabledByFailure supprimé, compteur reset');
+      logger.info('🔄 Migration: disabledByFailure removed, counter reset');
     }
 
     // Vérifier l'intégrité des identifiants après mise à jour
     const credCheck = await storage.verifyCredentialsIntegrity();
     if (credCheck.status === 'ok') {
-      logger.info('✅ Identifiants intacts après mise à jour');
+      logger.info('✅ Credentials intact after update');
     } else if (credCheck.status === 'corrupted') {
-      logger.warn('⚠️ Identifiants corrompus après mise à jour');
+      logger.warn('⚠️ Credentials corrupted after update');
     }
 
     // Sauvegarder les données actuelles vers sync après mise à jour
@@ -1266,7 +1267,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
 });
 
 chrome.runtime.onStartup.addListener(async () => {
-  logger.info('🚀 Extension démarrée');
+  logger.info('🚀 Extension started');
 
   // Nettoyer les fenêtres orphelines (veille, redémarrage, crash)
   await cleanupOrphanedWindow();
@@ -1280,7 +1281,7 @@ chrome.runtime.onStartup.addListener(async () => {
   const currentSettings = await storage.getSettings();
   if (currentSettings.autoCheckInterval !== 90) {
     await storage.saveSettings({ autoCheckInterval: 90 });
-    logger.info('⏰ Intervalle auto-check corrigé:', currentSettings.autoCheckInterval, '→ 90 min');
+    logger.info('⏰ Auto-check interval corrected:', currentSettings.autoCheckInterval, '→ 90 min');
   }
 
   // Synchroniser le backup au démarrage
@@ -1301,7 +1302,7 @@ chrome.storage.onChanged.addListener((changes, area) => {
     const oldEnabled = changes.settings.oldValue?.autoCheckEnabled;
     const newEnabled = changes.settings.newValue?.autoCheckEnabled;
     if (oldEnabled !== newEnabled) {
-      logger.info('⚙️ autoCheckEnabled changé via storage:', oldEnabled, '→', newEnabled);
+      logger.info('⚙️ autoCheckEnabled changed via storage:', oldEnabled, '→', newEnabled);
       scheduleAutoCheck();
     }
   }
@@ -1309,4 +1310,4 @@ chrome.storage.onChanged.addListener((changes, area) => {
 
 // ─────────────────────────────────────────────────────────────
 
-logger.info('=== Service Worker initialisé ===');
+logger.info('=== Service Worker initialized ===');

--- a/content/auto-login.js
+++ b/content/auto-login.js
@@ -75,7 +75,7 @@
   // ─────────────────────────────────────────────────────────────
 
   async function clickSeConnecter() {
-    log('📍 Page ANEF détectée');
+    log('📍 ANEF page detected');
 
     // Attendre que Angular charge
     await sleep(2000);
@@ -83,12 +83,12 @@
     const btn = await waitForElement('p-button.fullWidthButton button', 10000);
 
     if (!btn) {
-      log('❌ Bouton "Se connecter" non trouvé');
-      notifyExtension('NEED_CLICK_LOGIN', { error: 'Bouton non trouvé' });
+      log('❌ "Se connecter" button not found');
+      notifyExtension('NEED_CLICK_LOGIN', { error: 'Button not found' });
       return false;
     }
 
-    log('👆 Clic sur "Se connecter"');
+    log('👆 Clicking "Se connecter"');
     btn.click();
     notifyExtension('LOGIN_CLICKED', {});
 
@@ -100,7 +100,7 @@
   // ─────────────────────────────────────────────────────────────
 
   async function fillSSOForm(username, password) {
-    log('📍 Page SSO détectée');
+    log('📍 SSO page detected');
 
     const usernameInput = await waitForElement(
       "input[name='username'], input[type='email'], input[id='username']",
@@ -108,12 +108,12 @@
     );
 
     if (!usernameInput) {
-      log('❌ Champ identifiant non trouvé');
-      notifyExtension('LOGIN_FAILED', { error: 'Champ identifiant non trouvé' });
+      log('❌ Username field not found');
+      notifyExtension('LOGIN_FAILED', { error: 'Username field not found' });
       return false;
     }
 
-    log('📝 Saisie identifiant');
+    log('📝 Filling username');
     fillInput(usernameInput, username);
     await sleep(500);
 
@@ -122,12 +122,12 @@
     );
 
     if (!passwordInput) {
-      log('❌ Champ mot de passe non trouvé');
-      notifyExtension('LOGIN_FAILED', { error: 'Champ mot de passe non trouvé' });
+      log('❌ Password field not found');
+      notifyExtension('LOGIN_FAILED', { error: 'Password field not found' });
       return false;
     }
 
-    log('📝 Saisie mot de passe');
+    log('📝 Filling password');
     fillInput(passwordInput, password);
     await sleep(500);
 
@@ -136,12 +136,12 @@
     );
 
     if (!submitBtn) {
-      log('❌ Bouton de connexion non trouvé');
-      notifyExtension('LOGIN_FAILED', { error: 'Bouton submit non trouvé' });
+      log('❌ Submit button not found');
+      notifyExtension('LOGIN_FAILED', { error: 'Submit button not found' });
       return false;
     }
 
-    log('👆 Soumission du formulaire');
+    log('👆 Submitting form');
     submitBtn.click();
     notifyExtension('LOGIN_SUBMITTED', {});
 
@@ -153,11 +153,11 @@
   // ─────────────────────────────────────────────────────────────
 
   async function performAutoLogin(username, password) {
-    log('🚀 Démarrage connexion automatique');
+    log('🚀 Starting auto-login');
     log('📍 URL:', window.location.href);
 
     const pageType = detectPageType();
-    log('📄 Type de page:', pageType);
+    log('📄 Page type:', pageType);
 
     try {
       switch (pageType) {
@@ -170,21 +170,21 @@
           break;
 
         case 'LOGGED_IN':
-          log('✅ Déjà connecté');
+          log('✅ Already logged in');
           notifyExtension('LOGIN_SUCCESS', {});
           break;
 
         default:
-          log('⚠️ Page inconnue, tentative SSO');
+          log('⚠️ Unknown page, attempting SSO');
           const hasForm = document.querySelector("input[name='username'], input[type='email']");
           if (hasForm) {
             await fillSSOForm(username, password);
           } else {
-            notifyExtension('LOGIN_FAILED', { error: 'Page non reconnue' });
+            notifyExtension('LOGIN_FAILED', { error: 'Page not recognized' });
           }
       }
     } catch (error) {
-      log('❌ Erreur:', error.message);
+      log('❌ Error:', error.message);
       notifyExtension('LOGIN_FAILED', { error: error.message });
     }
   }
@@ -202,12 +202,12 @@
       if (username && password) {
         await performAutoLogin(username, password);
       } else {
-        log('❌ Identifiants manquants');
-        notifyExtension('LOGIN_FAILED', { error: 'Identifiants manquants' });
+        log('❌ Missing credentials');
+        notifyExtension('LOGIN_FAILED', { error: 'Missing credentials' });
       }
     }
   });
 
-  log('Script auto-login chargé');
+  log('Auto-login script loaded');
 
 })();

--- a/content/content-script.js
+++ b/content/content-script.js
@@ -55,7 +55,7 @@
   if (window.__ANEF_EXTENSION_INJECTED__) return;
   window.__ANEF_EXTENSION_INJECTED__ = true;
 
-  logger.info('Content Script chargé');
+  logger.info('Content Script loaded');
 
   // ─────────────────────────────────────────────────────────────
   // Injection du script d'interception
@@ -67,10 +67,10 @@
     // Passer l'URL locale de forge.js (le script injecté n'a pas accès à chrome.runtime)
     script.dataset.forgeUrl = chrome.runtime.getURL('lib/forge.min.js');
     script.onload = function() {
-      logger.info('✅ Script d\'interception injecté');
+      logger.info('✅ Interception script injected');
       this.remove();
     };
-    script.onerror = () => logger.error('Erreur injection script');
+    script.onerror = () => logger.error('Script injection error');
 
     (document.documentElement || document.head || document.body).appendChild(script);
   }
@@ -91,13 +91,13 @@
     const { type, data } = event.detail || {};
 
     if (!type || !ALLOWED_MESSAGE_TYPES.includes(type)) {
-      logger.warn('Type de message non autorisé ignoré:', type);
+      logger.warn('Unauthorized message type ignored:', type);
       return;
     }
 
     if (data) {
       safeSendMessage({ type, data })
-        .then(() => logger.info('📤 Données envoyées:', type));
+        .then(() => logger.info('📤 Data sent:', type));
     }
   });
 
@@ -119,7 +119,7 @@
 
       // Lancer la connexion automatique
       case 'DO_AUTO_LOGIN':
-        logger.info('🔐 Auto-login demandé');
+        logger.info('🔐 Auto-login requested');
         injectAutoLoginScript();
         setTimeout(() => {
           window.postMessage({
@@ -133,7 +133,7 @@
 
       // Déclencher la récupération des données
       case 'TRIGGER_DATA_FETCH':
-        logger.info('📥 Demande de récupération des données');
+        logger.info('📥 Data fetch requested');
         triggerDataFetch();
         sendResponse({ triggered: true });
         return true;
@@ -164,10 +164,10 @@
     const script = document.createElement('script');
     script.src = chrome.runtime.getURL('content/auto-login.js');
     script.onload = function() {
-      logger.info('✅ Script auto-login injecté');
+      logger.info('✅ Auto-login script injected');
       this.remove();
     };
-    script.onerror = () => logger.error('Erreur injection auto-login');
+    script.onerror = () => logger.error('Auto-login injection error');
 
     (document.documentElement || document.head || document.body).appendChild(script);
   }
@@ -178,7 +178,7 @@
     if (event.data?.source !== 'ANEF_AUTO_LOGIN') return;
 
     const { type, data } = event.data;
-    logger.info('📥 Résultat auto-login:', type);
+    logger.info('📥 Auto-login result:', type);
 
     safeSendMessage({ type, data });
   });
@@ -218,7 +218,7 @@
       if (location.href !== lastUrl) {
         const previousUrl = lastUrl;
         lastUrl = location.href;
-        logger.info('📍 Navigation détectée:', { from: previousUrl.split('#')[1], to: lastUrl.split('#')[1] });
+        logger.info('📍 Navigation detected:', { from: previousUrl.split('#')[1], to: lastUrl.split('#')[1] });
         safeSendMessage({ type: 'PAGE_CHANGED', url: lastUrl });
 
         // Si on arrive sur mon-compte après une connexion, relancer le script d'injection
@@ -229,7 +229,7 @@
         const isOnMonCompte = lastUrl.includes('mon-compte');
 
         if (isOnMonCompte && (wasOnLogin || !injectedScriptTriggered)) {
-          logger.info('🔄 Relance du script d\'interception après navigation');
+          logger.info('🔄 Re-launching interception script after navigation');
           injectedScriptTriggered = true;
           setTimeout(() => {
             triggerDataFetch();
@@ -279,7 +279,7 @@
                           referrer.includes('connexion');
 
     if (cameFromLogin) {
-      logger.info('🏠 Page d\'accueil après login, redirection vers mon-compte...');
+      logger.info('🏠 Homepage after login, redirecting to mon-compte...');
       window.location.href = 'https://administration-etrangers-en-france.interieur.gouv.fr/particuliers/#/espace-personnel/mon-compte';
     }
   }
@@ -297,7 +297,7 @@
       window.addEventListener('load', notifyReady);
     }
 
-    logger.info('Content Script initialisé');
+    logger.info('Content Script initialized');
   }
 
   if (document.readyState === 'loading') {

--- a/content/injected-script.js
+++ b/content/injected-script.js
@@ -44,7 +44,7 @@
     }));
   }
 
-  log('Script d\'interception chargé');
+  log('Interception script loaded');
 
   // ─────────────────────────────────────────────────────────────
   // Configuration des API
@@ -93,7 +93,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
   function decryptStatus(encryptedData) {
     try {
       if (typeof forge === 'undefined') {
-        log('forge.js non disponible');
+        log('forge.js not available');
         return encryptedData;
       }
 
@@ -101,7 +101,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
       if (!privateKey) {
         privateKey = forge.pki.privateKeyFromPem(PRIVATE_KEY.trim());
       }
-      if (!privateKey) throw new Error('Clé privée invalide');
+      if (!privateKey) throw new Error('Invalid private key');
 
       const decoded = forge.util.decode64(encryptedData);
       const buffer = forge.util.createBuffer(decoded, 'raw');
@@ -114,7 +114,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
       return decrypted.split('#K#')[0] || decrypted;
 
     } catch (error) {
-      log('Erreur déchiffrement:', error.message);
+      log('Decryption error:', error.message);
       return encryptedData;
     }
   }
@@ -140,17 +140,17 @@ QJNdXtE3G7SjkDOn36yZSaXp
       }
 
       if (!FORGE_URL) {
-        reject(new Error('URL forge.js non disponible'));
+        reject(new Error('forge.js URL not available'));
         return;
       }
 
       const script = document.createElement('script');
       script.src = FORGE_URL;
       script.onload = () => {
-        log('✅ forge.js chargé (local)');
+        log('✅ forge.js loaded (local)');
         resolve();
       };
-      script.onerror = () => reject(new Error('Échec chargement forge.js'));
+      script.onerror = () => reject(new Error('Failed to load forge.js'));
       document.head.appendChild(script);
     });
   }
@@ -203,24 +203,24 @@ QJNdXtE3G7SjkDOn36yZSaXp
   async function fetchDossierData() {
     try {
       const startTime = Date.now();
-      log('📡 Appel API dossier-stepper...');
+      log('📡 Calling dossier-stepper API...');
 
       const response = await fetch(API.DOSSIER_STEPPER);
-      log('📡 API répondu en ' + (Date.now() - startTime) + 'ms');
+      log('📡 API responded in ' + (Date.now() - startTime) + 'ms');
       if (!response.ok) {
         // HTTP 502/503 = maintenance probable
         if (response.status === 502 || response.status === 503) {
-          log('🔧 API en maintenance (HTTP ' + response.status + ')');
+          log('🔧 API under maintenance (HTTP ' + response.status + ')');
           sendToExtension('MAINTENANCE', { inMaintenance: true });
           return null;
         }
-        throw new Error(`Erreur ${response.status}`);
+        throw new Error(`Error ${response.status}`);
       }
 
       const data = await response.json();
 
       if (!data?.dossier?.statut) {
-        log('Pas de statut dans la réponse');
+        log('No status in response');
         return null;
       }
 
@@ -245,7 +245,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
       return { statut: decryptedStatus, date_statut: data.dossier.date_statut };
 
     } catch (error) {
-      log('Erreur récupération dossier:', error.message);
+      log('Error fetching dossier:', error.message);
       return null;
     }
   }
@@ -269,7 +269,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
 
   async function fetchDossierDetails(dossierId) {
     try {
-      log('📡 Appel API détails dossier...');
+      log('📡 Calling dossier details API...');
 
       const response = await fetch(API.DOSSIER_DETAILS + dossierId);
       if (!response.ok) return;
@@ -279,7 +279,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
 
       // Log diagnostic : clés de la réponse + recherche champ décret
       if (details) {
-        log('📋 Clés API détails: ' + Object.keys(details).join(', '));
+        log('📋 API details keys: ' + Object.keys(details).join(', '));
         // Recherche récursive de tout champ contenant "decret"
         var decretFields = [];
         (function findDecret(obj, path) {
@@ -294,7 +294,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
           }
         })(details, 'details');
         if (decretFields.length) {
-          log('📋 Champs décret trouvés: ' + decretFields.join(' | '));
+          log('📋 Decree fields found: ' + decretFields.join(' | '));
         }
       }
 
@@ -329,7 +329,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
       });
 
     } catch (error) {
-      log('Erreur récupération détails:', error.message);
+      log('Error fetching details:', error.message);
     }
   }
 
@@ -339,12 +339,12 @@ QJNdXtE3G7SjkDOn36yZSaXp
 
   async function waitForNationalityTab() {
     const MAX_WAIT = 30000;
-    log('⏳ Recherche onglet Nationalité...');
+    log('⏳ Looking for Nationality tab...');
 
     // Vérifier immédiatement
     const found = findNationalityTab();
     if (found) {
-      log('✅ Onglet Nationalité trouvé immédiatement');
+      log('✅ Nationality tab found immediately');
       return found;
     }
 
@@ -357,7 +357,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
         // Page d'erreur ou login
         if (document.querySelector('.error-page') || window.location.href.includes('connexion')) {
           observer.disconnect();
-          log('❌ Page d\'erreur ou de connexion détectée');
+          log('❌ Error or login page detected');
           resolve(null);
           return;
         }
@@ -375,7 +375,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
         const tab = findNationalityTab();
         if (tab) {
           observer.disconnect();
-          log('✅ Onglet Nationalité trouvé après ' + (Date.now() - startTime) + 'ms');
+          log('✅ Nationality tab found after ' + (Date.now() - startTime) + 'ms');
           resolve(tab);
         }
       });
@@ -394,7 +394,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
           const allTabs = document.querySelectorAll('a[role="tab"], li[role="presentation"] a, .p-tabview-nav a, .p-tabview-nav li, [role="tablist"] a, [role="tablist"] li');
           const allLinks = document.querySelectorAll('a');
           const tabTexts = Array.from(allTabs).map(el => '"' + (el.textContent || '').trim().substring(0, 40) + '"');
-          log('❌ Timeout: onglet non trouvé après ' + MAX_WAIT / 1000 + 's. DOM tabs: ' + allTabs.length + ' [' + tabTexts.join(', ') + ']. Total links: ' + allLinks.length + '. Body length: ' + (document.body?.innerHTML?.length || 0));
+          log('❌ Timeout: tab not found after ' + MAX_WAIT / 1000 + 's. DOM tabs: ' + allTabs.length + ' [' + tabTexts.join(', ') + ']. Total links: ' + allLinks.length + '. Body length: ' + (document.body?.innerHTML?.length || 0));
           resolve(null);
         }
       }, MAX_WAIT);
@@ -405,7 +405,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
     const tabs = document.querySelectorAll('a[role="tab"], li[role="presentation"] a, .p-tabview-nav a, .p-tabview-nav li, [role="tablist"] a, [role="tablist"] li');
     if (tabs.length > 0 && !findNationalityTab._logged) {
       findNationalityTab._logged = true;
-      log('🔍 Onglets DOM trouvés: ' + tabs.length + ' — textes: ' + Array.from(tabs).map(el => '"' + (el.textContent || '').trim().substring(0, 40) + '"').join(', '));
+      log('🔍 DOM tabs found: ' + tabs.length + ' — texts: ' + Array.from(tabs).map(el => '"' + (el.textContent || '').trim().substring(0, 40) + '"').join(', '));
     }
     return Array.from(tabs).find(
       el => el.textContent?.includes("Nationalité Française") ||
@@ -418,11 +418,11 @@ QJNdXtE3G7SjkDOn36yZSaXp
   /** Attend que le contenu de l'onglet soit chargé (MutationObserver) */
   async function waitForTabContent() {
     const MAX_WAIT = 3000;
-    log('⏳ Attente chargement contenu onglet...');
+    log('⏳ Waiting for tab content to load...');
 
     // Vérifier immédiatement
     if (isTabContentLoaded()) {
-      log('✅ Contenu onglet Nationalité déjà chargé');
+      log('✅ Nationality tab content already loaded');
       return;
     }
 
@@ -432,7 +432,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
       const observer = new MutationObserver(() => {
         if (isTabContentLoaded()) {
           observer.disconnect();
-          log('✅ Contenu onglet chargé après ' + (Date.now() - startTime) + 'ms');
+          log('✅ Tab content loaded after ' + (Date.now() - startTime) + 'ms');
           resolve();
         }
       });
@@ -443,7 +443,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
 
       setTimeout(() => {
         observer.disconnect();
-        log('⚠️ Timeout attente contenu (' + MAX_WAIT + 'ms), on continue');
+        log('⚠️ Timeout waiting for content (' + MAX_WAIT + 'ms), continuing');
         resolve();
       }, MAX_WAIT);
     });
@@ -493,7 +493,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
       !!(document.querySelector('h1')?.textContent?.includes('503'));
 
     if (isMaintenance) {
-      log('🔧 Site en maintenance détecté');
+      log('🔧 Site maintenance detected');
       sendToExtension('MAINTENANCE', { inMaintenance: true });
       return true;
     }
@@ -510,19 +510,19 @@ QJNdXtE3G7SjkDOn36yZSaXp
   async function main() {
     // Éviter les exécutions simultanées
     if (isRunning) {
-      log('⏳ Déjà en cours d\'exécution');
+      log('⏳ Already running');
       return;
     }
 
     // Vérifier qu'on est sur une page appropriée (pas login)
     const currentUrl = window.location.href;
     if (currentUrl.includes('connexion-inscription')) {
-      log('📍 Page de connexion, attente navigation...');
+      log('📍 Login page, waiting for navigation...');
       return;
     }
 
     isRunning = true;
-    log('🚀 Démarrage...');
+    log('🚀 Starting...');
 
     if (checkMaintenance()) {
       sendToExtension('FETCH_COMPLETE', { success: false, reason: 'maintenance' });
@@ -535,7 +535,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
     const jwtErrorHandler = function(event) {
       if (event.message && event.message.includes('doesn\'t appear to be a JWT')) {
         jwtErrorDetected = true;
-        log('🔑 Erreur JWT détectée — session invalide ou mot de passe expiré');
+        log('🔑 JWT error detected — invalid session or expired password');
       }
     };
     window.addEventListener('error', jwtErrorHandler);
@@ -543,13 +543,13 @@ QJNdXtE3G7SjkDOn36yZSaXp
     try {
       await loadForge();
     } catch {
-      log('forge.js non disponible, déchiffrement désactivé');
+      log('forge.js not available, decryption disabled');
     }
 
     // Si l'erreur JWT est déjà arrivée (elle arrive très vite), sortir immédiatement
     if (jwtErrorDetected) {
       window.removeEventListener('error', jwtErrorHandler);
-      log('❌ Session ANEF invalide (JWT expiré) — mot de passe à renouveler');
+      log('❌ Invalid ANEF session (expired JWT) — password needs renewal');
       sendToExtension('FETCH_COMPLETE', { success: false, reason: 'expired_session' });
       sendToExtension('EXPIRED_SESSION', { reason: 'jwt_invalid' });
       isRunning = false;
@@ -561,7 +561,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
 
     // Vérifier si l'erreur JWT est arrivée pendant l'attente
     if (jwtErrorDetected) {
-      log('❌ Session ANEF invalide (JWT expiré) — mot de passe à renouveler');
+      log('❌ Invalid ANEF session (expired JWT) — password needs renewal');
       sendToExtension('FETCH_COMPLETE', { success: false, reason: 'expired_session' });
       sendToExtension('EXPIRED_SESSION', { reason: 'jwt_invalid' });
       isRunning = false;
@@ -571,23 +571,23 @@ QJNdXtE3G7SjkDOn36yZSaXp
     if (!tab) {
       // Revérifier la maintenance (la page a pu finir de charger entre-temps)
       checkMaintenance();
-      log('❌ Onglet Nationalité non trouvé après attente');
+      log('❌ Nationality tab not found after waiting');
       sendToExtension('FETCH_COMPLETE', { success: false, reason: 'no_nationality_tab' });
       isRunning = false;
       return;
     }
 
     if (!tab.classList.contains('active')) {
-      log('👆 Activation onglet Nationalité');
+      log('👆 Activating Nationality tab');
       tab.click();
       // Petit délai pour laisser Angular réagir au clic
       await new Promise(r => setTimeout(r, 500));
     }
 
-    log('📡 Lancement récupération données...');
+    log('📡 Starting data fetch...');
     const result = await fetchDossierData();
     if (result) {
-      log('✅ Données récupérées');
+      log('✅ Data retrieved');
       hasRun = true;
       sendToExtension('FETCH_COMPLETE', { success: true });
     } else {
@@ -608,7 +608,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
     if (event.data?.source !== 'ANEF_EXTENSION') return;
 
     if (event.data.type === 'TRIGGER_DATA_FETCH') {
-      log('📥 Demande de récupération des données reçue');
+      log('📥 Data fetch request received');
       await main();
     }
   });
@@ -617,7 +617,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
   function startWhenReady() {
     // Ne démarrer que si on est sur mon-compte
     if (!window.location.href.includes('mon-compte')) {
-      log('📍 Pas sur mon-compte, attente navigation...');
+      log('📍 Not on mon-compte, waiting for navigation...');
       // Vérifier quand même la maintenance (le site peut avoir redirigé)
       setTimeout(() => {
         if (checkMaintenance()) {
@@ -629,7 +629,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
 
     // Vérifier immédiatement
     if (document.querySelector('app-root, [ng-version], .p-tabview, router-outlet')) {
-      log('✅ Angular détecté immédiatement');
+      log('✅ Angular detected immediately');
       main();
       return;
     }
@@ -641,7 +641,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
     const observer = new MutationObserver(() => {
       if (document.querySelector('app-root, [ng-version], .p-tabview, router-outlet')) {
         observer.disconnect();
-        log('✅ Angular détecté (après ' + (Date.now() - startTime) + 'ms)');
+        log('✅ Angular detected (after ' + (Date.now() - startTime) + 'ms)');
         main();
       }
     });
@@ -662,7 +662,7 @@ QJNdXtE3G7SjkDOn36yZSaXp
     setTimeout(() => {
       observer.disconnect();
       if (!isRunning && !hasRun) {
-        log('⚠️ Timeout détection Angular, démarrage forcé');
+        log('⚠️ Angular detection timeout, forced start');
         main();
       }
     }, MAX_WAIT);

--- a/lib/i18n-helper.js
+++ b/lib/i18n-helper.js
@@ -1,0 +1,42 @@
+/**
+ * Helpers i18n pour l'extension ANEF Status Tracker.
+ * Utilise l'API native chrome.i18n.getMessage().
+ */
+
+/** Raccourci pour chrome.i18n.getMessage */
+export function t(key, substitutions) {
+  return chrome.i18n.getMessage(key, substitutions) || key;
+}
+
+/**
+ * Traduit tous les éléments d'une page portant des attributs data-i18n.
+ *
+ * Attributs reconnus :
+ *   data-i18n          → remplace textContent
+ *   data-i18n-title    → remplace title
+ *   data-i18n-placeholder → remplace placeholder
+ *   data-i18n-html     → remplace innerHTML (pour les liens intégrés)
+ */
+export function translatePage() {
+  for (const el of document.querySelectorAll('[data-i18n]')) {
+    const msg = chrome.i18n.getMessage(el.getAttribute('data-i18n'));
+    if (msg) el.textContent = msg;
+  }
+  for (const el of document.querySelectorAll('[data-i18n-title]')) {
+    const msg = chrome.i18n.getMessage(el.getAttribute('data-i18n-title'));
+    if (msg) el.title = msg;
+  }
+  for (const el of document.querySelectorAll('[data-i18n-placeholder]')) {
+    const msg = chrome.i18n.getMessage(el.getAttribute('data-i18n-placeholder'));
+    if (msg) el.placeholder = msg;
+  }
+  for (const el of document.querySelectorAll('[data-i18n-html]')) {
+    const msg = chrome.i18n.getMessage(el.getAttribute('data-i18n-html'));
+    if (msg) el.innerHTML = msg;
+  }
+}
+
+/** Returns the locale string for Intl/toLocaleString calls */
+export function getLocale() {
+  return chrome.i18n.getUILanguage() || 'fr';
+}

--- a/lib/status-parser.js
+++ b/lib/status-parser.js
@@ -8,422 +8,424 @@
  * - Numéro d'étape (1-12)
  */
 
+import { t, getLocale } from './i18n-helper.js';
+
 const STATUTS = {
   // ── Étape 1 : Brouillon ──────────────────────────────────────
   "draft": {
-    phase: "Brouillon",
-    explication: "Dossier en brouillon",
+    phaseKey: "status_draft_phase",
+    explicationKey: "status_draft_explication",
     etape: 1,
     rang: 100,
-    description: "Votre dossier est en cours de préparation sur la plateforme ANEF. Complétez toutes les sections et joignez les pièces justificatives avant de soumettre.",
+    descriptionKey: "status_draft_description",
     icon: "📝"
   },
 
   // ── Étape 2 : Dépôt du dossier ───────────────────────────────
   "dossier_depose": {
-    phase: "Dépôt",
-    explication: "Dossier déposé",
+    phaseKey: "status_dossier_depose_phase",
+    explicationKey: "status_dossier_depose_explication",
     etape: 2,
     rang: 200,
-    description: "Votre dossier a été soumis avec succès. Il est dans la file d'attente de la préfecture pour un premier examen de recevabilité.",
+    descriptionKey: "status_dossier_depose_description",
     icon: "📨"
   },
 
   // ── Étape 3 : Vérification formelle ──────────────────────────
   "verification_formelle_a_traiter": {
-    phase: "Vérification formelle",
-    explication: "Dossier reçu, en tri",
+    phaseKey: "status_verification_formelle_a_traiter_phase",
+    explicationKey: "status_verification_formelle_a_traiter_explication",
     etape: 3,
     rang: 301,
-    description: "La préfecture a bien reçu votre demande. Elle est placée en file d'attente pour le premier tri administratif : vérification des pièces obligatoires et conditions de base.",
+    descriptionKey: "status_verification_formelle_a_traiter_description",
     icon: "🔍"
   },
   "verification_formelle_en_cours": {
-    phase: "Vérification formelle",
-    explication: "Tri en cours",
+    phaseKey: "status_verification_formelle_en_cours_phase",
+    explicationKey: "status_verification_formelle_en_cours_explication",
     etape: 3,
     rang: 302,
-    description: "Un agent vérifie l'admissibilité formelle de votre dossier : présence des documents requis, validité des pièces, conditions légales. Des compléments peuvent être demandés.",
+    descriptionKey: "status_verification_formelle_en_cours_description",
     icon: "🔍"
   },
   "verification_formelle_mise_en_demeure": {
-    phase: "Vérification formelle",
-    explication: "Mise en demeure, pièces à fournir",
+    phaseKey: "status_verification_formelle_mise_en_demeure_phase",
+    explicationKey: "status_verification_formelle_mise_en_demeure_explication",
     etape: 3,
     rang: 303,
-    description: "Des documents obligatoires sont manquants ou non conformes. Vous allez recevoir un courrier détaillant les pièces à fournir. Répondez dans le délai imparti pour éviter un classement sans suite.",
+    descriptionKey: "status_verification_formelle_mise_en_demeure_description",
     icon: "⚠️"
   },
   "css_mise_en_demeure_a_affecter": {
-    phase: "Vérification formelle",
-    explication: "Classement sans suite en cours",
+    phaseKey: "status_css_mise_en_demeure_a_affecter_phase",
+    explicationKey: "status_css_mise_en_demeure_a_affecter_explication",
     etape: 3,
     rang: 304,
-    description: "Suite à la mise en demeure restée sans réponse, un classement sans suite est en cours d'affectation à un agent. Fournissez les pièces manquantes au plus vite.",
+    descriptionKey: "status_css_mise_en_demeure_a_affecter_description",
     icon: "⚠️"
   },
   "css_mise_en_demeure_a_rediger": {
-    phase: "Vérification formelle",
-    explication: "Classement sans suite en rédaction",
+    phaseKey: "status_css_mise_en_demeure_a_rediger_phase",
+    explicationKey: "status_css_mise_en_demeure_a_rediger_explication",
     etape: 3,
     rang: 305,
-    description: "Le classement sans suite de votre dossier est en cours de rédaction suite à l'absence de réponse à la mise en demeure. Contactez votre préfecture si vous avez transmis les pièces.",
+    descriptionKey: "status_css_mise_en_demeure_a_rediger_description",
     icon: "⚠️"
   },
 
   // ── Étape 4 : Affectation instructeur ────────────────────────
   "instruction_a_affecter": {
-    phase: "Affectation",
-    explication: "Dossier recevable, attente d'affectation",
+    phaseKey: "status_instruction_a_affecter_phase",
+    explicationKey: "status_instruction_a_affecter_explication",
     etape: 4,
     rang: 400,
-    description: "Votre dossier a passé la vérification formelle avec succès ! Il est déclaré recevable et attend d'être attribué à un agent instructeur pour un examen approfondi. Vous recevrez un récépissé de dépôt.",
+    descriptionKey: "status_instruction_a_affecter_description",
     icon: "👤"
   },
 
   // ── Étape 5 : Instruction du dossier ─────────────────────────
   "instruction_recepisse_completude_a_envoyer": {
-    phase: "Instruction",
-    explication: "Dossier complet, examen approfondi",
+    phaseKey: "status_instruction_recepisse_completude_a_envoyer_phase",
+    explicationKey: "status_instruction_recepisse_completude_a_envoyer_explication",
     etape: 5,
     rang: 501,
-    description: "Un agent instructeur examine en détail votre dossier : situation personnelle, professionnelle, fiscale, assimilation. Le récépissé de complétude sera envoyé. Il peut vous convoquer pour l'entretien.",
+    descriptionKey: "status_instruction_recepisse_completude_a_envoyer_description",
     icon: "📖"
   },
   "instruction_recepisse_completude_a_envoyer_retour_complement_a_traiter": {
-    phase: "Instruction",
-    explication: "Compléments reçus, à vérifier",
+    phaseKey: "status_instruction_recepisse_completude_a_envoyer_retour_complement_a_traiter_phase",
+    explicationKey: "status_instruction_recepisse_completude_a_envoyer_retour_complement_a_traiter_explication",
     etape: 5,
     rang: 502,
-    description: "Vous avez fourni des documents complémentaires suite à une demande de l'instructeur. L'agent vérifie leur conformité avant de poursuivre l'instruction de votre dossier.",
+    descriptionKey: "status_instruction_recepisse_completude_a_envoyer_retour_complement_a_traiter_description",
     icon: "📋"
   },
 
   // ── Étape 6 : Complétude & enquêtes ──────────────────────────
   "instruction_date_ea_a_fixer": {
-    phase: "Complétude & enquêtes",
-    explication: "Enquêtes administratives lancées",
+    phaseKey: "status_instruction_date_ea_a_fixer_phase",
+    explicationKey: "status_instruction_date_ea_a_fixer_explication",
     etape: 6,
     rang: 601,
-    description: "Votre dossier est officiellement complet ! Les enquêtes administratives obligatoires sont lancées (casier judiciaire, renseignements, fichiers). La date d'entretien d'assimilation sera fixée prochainement.",
+    descriptionKey: "status_instruction_date_ea_a_fixer_description",
     icon: "🔎"
   },
   "ea_demande_report_ea": {
-    phase: "Complétude & enquêtes",
-    explication: "Demande de report d'entretien",
+    phaseKey: "status_ea_demande_report_ea_phase",
+    explicationKey: "status_ea_demande_report_ea_explication",
     etape: 6,
     rang: 602,
-    description: "Une demande de report de l'entretien d'assimilation a été enregistrée. La préfecture vous proposera une nouvelle date. Attention aux délais pour ne pas retarder votre dossier.",
+    descriptionKey: "status_ea_demande_report_ea_description",
     icon: "🔄"
   },
 
   // ── Étape 7 : Entretien d'assimilation ───────────────────────
   "ea_en_attente_ea": {
-    phase: "Entretien d'assimilation",
-    explication: "Convocation envoyée, en attente",
+    phaseKey: "status_ea_en_attente_ea_phase",
+    explicationKey: "status_ea_en_attente_ea_explication",
     etape: 7,
     rang: 701,
-    description: "Votre convocation à l'entretien d'assimilation est envoyée ou disponible. Préparez-vous : questions sur la France (histoire, culture, valeurs républicaines), votre parcours et vos motivations.",
+    descriptionKey: "status_ea_en_attente_ea_description",
     icon: "📬"
   },
   "ea_crea_a_valider": {
-    phase: "Entretien d'assimilation",
-    explication: "Entretien passé, compte-rendu en rédaction",
+    phaseKey: "status_ea_crea_a_valider_phase",
+    explicationKey: "status_ea_crea_a_valider_explication",
     etape: 7,
     rang: 702,
-    description: "Vous avez passé l'entretien d'assimilation ! L'agent rédige le compte-rendu évaluant votre niveau de langue, connaissance de la France et assimilation à la communauté française.",
+    descriptionKey: "status_ea_crea_a_valider_description",
     icon: "✅"
   },
 
   // ── Étape 8 : Décision préfecture ────────────────────────────
   "prop_decision_pref_a_effectuer": {
-    phase: "Décision préfecture",
-    explication: "Avis préfectoral en cours",
+    phaseKey: "status_prop_decision_pref_a_effectuer_phase",
+    explicationKey: "status_prop_decision_pref_a_effectuer_explication",
     etape: 8,
     rang: 801,
-    description: "L'agent instructeur analyse l'ensemble de votre dossier (enquêtes, entretien, pièces) pour formuler sa proposition d'avis : favorable, défavorable ou ajournement.",
+    descriptionKey: "status_prop_decision_pref_a_effectuer_description",
     icon: "⚖️"
   },
   "prop_decision_pref_en_attente_retour_hierarchique": {
-    phase: "Décision préfecture",
-    explication: "Validation hiérarchique en cours",
+    phaseKey: "status_prop_decision_pref_en_attente_retour_hierarchique_phase",
+    explicationKey: "status_prop_decision_pref_en_attente_retour_hierarchique_explication",
     etape: 8,
     rang: 802,
-    description: "La proposition de l'agent est soumise à sa hiérarchie pour validation. Cette étape permet de confirmer l'avis avant transmission au préfet. Durée variable selon les préfectures.",
+    descriptionKey: "status_prop_decision_pref_en_attente_retour_hierarchique_description",
     icon: "👔"
   },
   "prop_decision_pref_prop_a_editer": {
-    phase: "Décision préfecture",
-    explication: "Rédaction de la proposition",
+    phaseKey: "status_prop_decision_pref_prop_a_editer_phase",
+    explicationKey: "status_prop_decision_pref_prop_a_editer_explication",
     etape: 8,
     rang: 803,
-    description: "L'avis est validé et le document officiel de proposition est en cours de rédaction. Il résume votre situation et la recommandation de la préfecture au ministère.",
+    descriptionKey: "status_prop_decision_pref_prop_a_editer_description",
     icon: "📝"
   },
   "prop_decision_pref_en_attente_retour_signataire": {
-    phase: "Décision préfecture",
-    explication: "Attente signature du préfet",
+    phaseKey: "status_prop_decision_pref_en_attente_retour_signataire_phase",
+    explicationKey: "status_prop_decision_pref_en_attente_retour_signataire_explication",
     etape: 8,
     rang: 804,
-    description: "Le document de proposition est finalisé et transmis au préfet (ou son représentant) pour signature. Une fois signé, votre dossier sera envoyé au ministère de l'Intérieur (SDANF).",
+    descriptionKey: "status_prop_decision_pref_en_attente_retour_signataire_description",
     icon: "✍️"
   },
 
   // ── Étape 9 : Contrôle SDANF & SCEC ─────────────────────────
   "controle_a_affecter": {
-    phase: "Contrôle SDANF",
-    explication: "Arrivé à la SDANF, attente affectation",
+    phaseKey: "status_controle_a_affecter_phase",
+    explicationKey: "status_controle_a_affecter_explication",
     etape: 9,
     rang: 901,
-    description: "Votre dossier est arrivé à la Sous-Direction de l'Accès à la Nationalité Française (SDANF) à Rezé (44). Il attend d'être attribué à un agent pour le contrôle ministériel.",
+    descriptionKey: "status_controle_a_affecter_description",
     icon: "🏛️"
   },
   "controle_a_effectuer": {
-    phase: "Contrôle SDANF",
-    explication: "Contrôle ministériel en cours",
+    phaseKey: "status_controle_a_effectuer_phase",
+    explicationKey: "status_controle_a_effectuer_explication",
     etape: 9,
     rang: 902,
-    description: "Un agent de la SDANF contrôle votre dossier : vérification des pièces d'état civil, cohérence des informations, respect des conditions légales. Cette étape peut prendre plusieurs semaines.",
+    descriptionKey: "status_controle_a_effectuer_description",
     icon: "📑"
   },
   "controle_en_attente_pec": {
-    phase: "Contrôle SCEC",
-    explication: "Transmis au SCEC de Nantes",
+    phaseKey: "status_controle_en_attente_pec_phase",
+    explicationKey: "status_controle_en_attente_pec_explication",
     etape: 9,
     rang: 903,
-    description: "Le Service Central d'État Civil (SCEC) de Nantes vérifie l'authenticité de vos actes d'état civil étrangers. Cette vérification est obligatoire pour valider votre identité.",
+    descriptionKey: "status_controle_en_attente_pec_description",
     icon: "🏛️"
   },
   "controle_pec_a_faire": {
-    phase: "Contrôle SCEC",
-    explication: "Vérification d'état civil en cours",
+    phaseKey: "status_controle_pec_a_faire_phase",
+    explicationKey: "status_controle_pec_a_faire_explication",
     etape: 9,
     rang: 904,
-    description: "Le SCEC procède à la vérification de vos pièces d'état civil. Une fois validées, vos actes seront transcrits dans les registres français si votre naturalisation aboutit.",
+    descriptionKey: "status_controle_pec_a_faire_description",
     icon: "✔️"
   },
 
   // ── Étape 10 : Préparation décret ────────────────────────────
   "controle_transmise_pour_decret": {
-    phase: "Préparation décret",
-    explication: "Avis FAVORABLE, transmis pour décret",
+    phaseKey: "status_controle_transmise_pour_decret_phase",
+    explicationKey: "status_controle_transmise_pour_decret_explication",
     etape: 10,
     rang: 1001,
-    description: "Excellente nouvelle ! L'avis est FAVORABLE. Votre dossier est transmis au service des décrets pour être inclus dans un prochain décret de naturalisation. La fin approche !",
+    descriptionKey: "status_controle_transmise_pour_decret_description",
     icon: "🎉"
   },
   "controle_en_attente_retour_hierarchique": {
-    phase: "Préparation décret",
-    explication: "Validation hiérarchique ministérielle",
+    phaseKey: "status_controle_en_attente_retour_hierarchique_phase",
+    explicationKey: "status_controle_en_attente_retour_hierarchique_explication",
     etape: 10,
     rang: 1002,
-    description: "Le projet de décret incluant votre demande est soumis à la validation de la hiérarchie ministérielle. Étape administrative normale avant la finalisation du décret.",
+    descriptionKey: "status_controle_en_attente_retour_hierarchique_description",
     icon: "👔"
   },
   "controle_decision_a_editer": {
-    phase: "Préparation décret",
-    explication: "Décision favorable, édition en cours",
+    phaseKey: "status_controle_decision_a_editer_phase",
+    explicationKey: "status_controle_decision_a_editer_explication",
     etape: 10,
     rang: 1003,
-    description: "La décision favorable est confirmée. Le document officiel du décret incluant votre nom est en cours d'édition. Vous serez bientôt inscrit(e) dans un décret de naturalisation.",
+    descriptionKey: "status_controle_decision_a_editer_description",
     icon: "📄"
   },
   "controle_en_attente_signature": {
-    phase: "Préparation décret",
-    explication: "Attente signature ministérielle",
+    phaseKey: "status_controle_en_attente_signature_phase",
+    explicationKey: "status_controle_en_attente_signature_explication",
     etape: 10,
     rang: 1004,
-    description: "Le décret de naturalisation est finalisé et attend la signature du ministre ou de son représentant. Une fois signé, il sera publié au Journal Officiel.",
+    descriptionKey: "status_controle_en_attente_signature_description",
     icon: "✍️"
   },
   "transmis_a_ac": {
-    phase: "Préparation décret",
-    explication: "Transmis à l'administration centrale",
+    phaseKey: "status_transmis_a_ac_phase",
+    explicationKey: "status_transmis_a_ac_explication",
     etape: 10,
     rang: 1005,
-    description: "Votre dossier favorable est transmis à l'administration centrale chargée de préparer les décrets. Vous êtes dans la dernière ligne droite de la procédure !",
+    descriptionKey: "status_transmis_a_ac_description",
     icon: "📬"
   },
   "a_verifier_avant_insertion_decret": {
-    phase: "Préparation décret",
-    explication: "Vérifications finales avant insertion",
+    phaseKey: "status_a_verifier_avant_insertion_decret_phase",
+    explicationKey: "status_a_verifier_avant_insertion_decret_explication",
     etape: 10,
     rang: 1006,
-    description: "Dernières vérifications administratives aléatoires et facultatives avant l'insertion de votre nom dans un décret. On s'assure qu'aucun élément nouveau ne s'oppose à votre naturalisation.",
+    descriptionKey: "status_a_verifier_avant_insertion_decret_description",
     icon: "🔎"
   },
   "prete_pour_insertion_decret": {
-    phase: "Préparation décret",
-    explication: "Validé, prêt pour insertion au décret",
+    phaseKey: "status_prete_pour_insertion_decret_phase",
+    explicationKey: "status_prete_pour_insertion_decret_explication",
     etape: 10,
     rang: 1007,
-    description: "Votre dossier est validé et prêt pour être inséré dans le prochain décret de naturalisation. La décision favorable a été signée par le Ministre !",
+    descriptionKey: "status_prete_pour_insertion_decret_description",
     icon: "✅"
   },
   "decret_en_preparation": {
-    phase: "Préparation décret",
-    explication: "Décret en cours de préparation",
+    phaseKey: "status_decret_en_preparation_phase",
+    explicationKey: "status_decret_en_preparation_explication",
     etape: 10,
     rang: 1008,
-    description: "Un décret de naturalisation incluant votre nom est en cours de préparation. Plusieurs dossiers sont regroupés dans chaque décret avant publication au Journal Officiel.",
+    descriptionKey: "status_decret_en_preparation_description",
     icon: "📋"
   },
   "decret_a_qualifier": {
-    phase: "Préparation décret",
-    explication: "Décret en cours de qualification",
+    phaseKey: "status_decret_a_qualifier_phase",
+    explicationKey: "status_decret_a_qualifier_explication",
     etape: 10,
     rang: 1009,
-    description: "Le décret incluant votre nom est en phase de qualification : catégorisation et vérification du type de décret (naturalisation, réintégration, etc.) avant validation finale.",
+    descriptionKey: "status_decret_a_qualifier_description",
     icon: "📋"
   },
   "decret_en_validation": {
-    phase: "Préparation décret",
-    explication: "Décret en validation finale",
+    phaseKey: "status_decret_en_validation_phase",
+    explicationKey: "status_decret_en_validation_explication",
     etape: 10,
     rang: 1010,
-    description: "Le décret de naturalisation est en cours de validation finale par les services compétents. Dernière étape administrative avant la signature et la publication.",
+    descriptionKey: "status_decret_en_validation_description",
     icon: "📋"
   },
 
   // ── Étape 11 : Publication JO ────────────────────────────────
   "inseree_dans_decret": {
-    phase: "Publication JO",
-    explication: "Inséré dans un décret signé",
+    phaseKey: "status_inseree_dans_decret_phase",
+    explicationKey: "status_inseree_dans_decret_explication",
     etape: 11,
     rang: 1101,
-    description: "Votre nom est officiellement inscrit dans un décret de naturalisation ! Il attend maintenant la publication au Journal Officiel de la République Française.",
+    descriptionKey: "status_inseree_dans_decret_description",
     icon: "🎉"
   },
   "decret_envoye_prefecture": {
-    phase: "Publication JO",
-    explication: "Décret envoyé à votre préfecture",
+    phaseKey: "status_decret_envoye_prefecture_phase",
+    explicationKey: "status_decret_envoye_prefecture_explication",
     etape: 11,
     rang: 1102,
-    description: "Le décret signé a été transmis à votre préfecture. Elle va vous convoquer pour la cérémonie d'accueil dans la citoyenneté française et la remise de votre décret.",
+    descriptionKey: "status_decret_envoye_prefecture_description",
     icon: "📨"
   },
   "notification_envoyee": {
-    phase: "Publication JO",
-    explication: "Notification officielle envoyée",
+    phaseKey: "status_notification_envoyee_phase",
+    explicationKey: "status_notification_envoyee_explication",
     etape: 11,
     rang: 1103,
-    description: "La notification officielle de votre naturalisation vous a été envoyée. Vous serez convoqué(e) à la cérémonie d'accueil dans la citoyenneté française.",
+    descriptionKey: "status_notification_envoyee_description",
     icon: "📬"
   },
 
   // ── Étape 12 : Décision finale ───────────────────────────────
   // Décisions positives
   "decret_naturalisation_publie": {
-    phase: "NATURALISÉ(E)",
-    explication: "Décret publié au Journal Officiel",
+    phaseKey: "status_decret_naturalisation_publie_phase",
+    explicationKey: "status_decret_naturalisation_publie_explication",
     etape: 12,
     rang: 1201,
-    description: "FÉLICITATIONS ! Votre décret de naturalisation est publié au Journal Officiel de la République Française. Vous êtes officiellement citoyen(ne) français(e) !",
+    descriptionKey: "status_decret_naturalisation_publie_description",
     icon: "🇫🇷"
   },
   "decret_naturalisation_publie_jo": {
-    phase: "NATURALISÉ(E)",
-    explication: "Décret publié au Journal Officiel",
+    phaseKey: "status_decret_naturalisation_publie_jo_phase",
+    explicationKey: "status_decret_naturalisation_publie_jo_explication",
     etape: 12,
     rang: 1202,
-    description: "FÉLICITATIONS ! Votre décret de naturalisation est publié au Journal Officiel. Vous êtes officiellement français(e) ! La préfecture vous convoquera pour la cérémonie.",
+    descriptionKey: "status_decret_naturalisation_publie_jo_description",
     icon: "🇫🇷"
   },
   "decret_publie": {
-    phase: "NATURALISÉ(E)",
-    explication: "Décret publié",
+    phaseKey: "status_decret_publie_phase",
+    explicationKey: "status_decret_publie_explication",
     etape: 12,
     rang: 1203,
-    description: "FÉLICITATIONS ! Votre décret de naturalisation est publié. Vous êtes officiellement citoyen(ne) français(e) ! La préfecture vous convoquera pour la cérémonie d'accueil.",
+    descriptionKey: "status_decret_publie_description",
     icon: "🇫🇷"
   },
   "demande_traitee": {
-    phase: "Finalisé",
-    explication: "Demande entièrement traitée",
+    phaseKey: "status_demande_traitee_phase",
+    explicationKey: "status_demande_traitee_explication",
     etape: 12,
     rang: 1204,
-    description: "Votre demande de naturalisation a été entièrement traitée. Consultez vos courriers ou contactez votre préfecture pour connaître l'issue de votre dossier.",
+    descriptionKey: "status_demande_traitee_description",
     icon: "✅"
   },
   // Décisions négatives
   "decision_negative_en_delais_recours": {
-    phase: "Décision négative",
-    explication: "Défavorable, délai de recours ouvert",
+    phaseKey: "status_decision_negative_en_delais_recours_phase",
+    explicationKey: "status_decision_negative_en_delais_recours_explication",
     etape: 12,
     rang: 1205,
-    description: "Votre demande a reçu une décision défavorable. Vous disposez d'un délai de 2 mois pour former un recours gracieux auprès du ministre (RAPO) ou un recours contentieux devant le tribunal administratif.",
+    descriptionKey: "status_decision_negative_en_delais_recours_description",
     icon: "❌"
   },
   "decision_notifiee": {
-    phase: "Décision négative",
-    explication: "Décision notifiée au demandeur",
+    phaseKey: "status_decision_notifiee_phase",
+    explicationKey: "status_decision_notifiee_explication",
     etape: 12,
     rang: 1206,
-    description: "La décision concernant votre dossier vous a été officiellement notifiée. Consultez le courrier pour connaître la nature de la décision et les voies de recours disponibles.",
+    descriptionKey: "status_decision_notifiee_description",
     icon: "❌"
   },
   "demande_en_cours_rapo": {
-    phase: "Recours RAPO",
-    explication: "Recours administratif en cours",
+    phaseKey: "status_demande_en_cours_rapo_phase",
+    explicationKey: "status_demande_en_cours_rapo_explication",
     etape: 12,
     rang: 1207,
-    description: "Votre recours administratif préalable obligatoire (RAPO) est en cours d'examen par le ministère. Le RAPO est un recours gracieux contre une décision défavorable. Délai de réponse : environ 4 mois.",
+    descriptionKey: "status_demande_en_cours_rapo_description",
     icon: "⚖️"
   },
   "controle_demande_notifiee": {
-    phase: "Décision notifiée",
-    explication: "Décision de contrôle notifiée",
+    phaseKey: "status_controle_demande_notifiee_phase",
+    explicationKey: "status_controle_demande_notifiee_explication",
     etape: 12,
     rang: 1208,
-    description: "La décision issue du contrôle ministériel vous a été officiellement communiquée. Vérifiez vos courriers pour connaître la suite donnée à votre dossier.",
+    descriptionKey: "status_controle_demande_notifiee_description",
     icon: "📬"
   },
   // Irrecevabilité
   "irrecevabilite_manifeste": {
-    phase: "Irrecevabilité",
-    explication: "Conditions légales non remplies",
+    phaseKey: "status_irrecevabilite_manifeste_phase",
+    explicationKey: "status_irrecevabilite_manifeste_explication",
     etape: 12,
     rang: 1209,
-    description: "Votre demande ne remplit pas les conditions légales de recevabilité (durée de résidence, titre de séjour, etc.). Vérifiez les critères d'éligibilité avant de déposer une nouvelle demande.",
+    descriptionKey: "status_irrecevabilite_manifeste_description",
     icon: "❌"
   },
   "irrecevabilite_manifeste_en_delais_recours": {
-    phase: "Irrecevabilité",
-    explication: "Irrecevable, délai de recours ouvert",
+    phaseKey: "status_irrecevabilite_manifeste_en_delais_recours_phase",
+    explicationKey: "status_irrecevabilite_manifeste_en_delais_recours_explication",
     etape: 12,
     rang: 1210,
-    description: "Votre demande a été déclarée irrecevable. Vous pouvez contester cette décision par un recours gracieux (RAPO) ou contentieux dans un délai de 2 mois.",
+    descriptionKey: "status_irrecevabilite_manifeste_en_delais_recours_description",
     icon: "❌"
   },
   // Classement sans suite
   "css_en_delais_recours": {
-    phase: "Classement sans suite",
-    explication: "Classé sans suite, recours possible",
+    phaseKey: "status_css_en_delais_recours_phase",
+    explicationKey: "status_css_en_delais_recours_explication",
     etape: 12,
     rang: 1211,
-    description: "Votre dossier a été classé sans suite (pièces non fournies dans les délais, désistement, etc.). Vous pouvez former un recours ou déposer une nouvelle demande complète.",
+    descriptionKey: "status_css_en_delais_recours_description",
     icon: "⚠️"
   },
   "css_notifie": {
-    phase: "Classement sans suite",
-    explication: "Classement sans suite notifié",
+    phaseKey: "status_css_notifie_phase",
+    explicationKey: "status_css_notifie_explication",
     etape: 12,
     rang: 1212,
-    description: "Le classement sans suite de votre dossier vous a été officiellement notifié. Analysez les motifs indiqués avant d'envisager une nouvelle demande.",
+    descriptionKey: "status_css_notifie_description",
     icon: "⚠️"
   }
 };
 
 /** Étapes principales avec leur statut canonique pour la saisie manuelle */
 export const STEP_DEFAULTS = [
-  { etape: 2, statut: 'dossier_depose', label: 'Dépôt du dossier', code: 'dossier_depose', icon: '📨', locked: true },
-  { etape: 7, statut: 'ea_en_attente_ea', label: 'Entretien d\'assimilation', code: 'ea_en_attente_ea', icon: '🗣️', locked: true },
-  { etape: 9, statut: 'controle_a_affecter', label: 'SDANF — Attente affectation', code: 'controle_a_affecter', icon: '🏛️', sub: '9.1' },
-  { etape: 9, statut: 'controle_a_effectuer', label: 'SDANF — Contrôle en cours', code: 'controle_a_effectuer', icon: '📑', sub: '9.2' },
-  { etape: 9, statut: 'controle_en_attente_pec', label: 'SCEC — Transmis Nantes', code: 'controle_en_attente_pec', icon: '🏛️', sub: '9.3' },
-  { etape: 10, statut: 'prete_pour_insertion_decret', label: 'PPID — Prêt pour insertion décret', code: 'prete_pour_insertion_decret', icon: '✅', sub: '10.7' },
-  { etape: 11, statut: 'inseree_dans_decret', label: 'IDD — Inséré dans le décret', code: 'inseree_dans_decret', icon: '📜', sub: '11.1' },
-  { etape: 12, statut: 'decret_naturalisation_publie', label: 'Publication au JO', code: 'decret_naturalisation_publie', icon: '🇫🇷' }
+  { etape: 2, statut: 'dossier_depose', label: t('step_dossier_depose_label'), code: 'dossier_depose', icon: '📨', locked: true },
+  { etape: 7, statut: 'ea_en_attente_ea', label: t('step_ea_en_attente_ea_label'), code: 'ea_en_attente_ea', icon: '🗣️', locked: true },
+  { etape: 9, statut: 'controle_a_affecter', label: t('step_controle_a_affecter_label'), code: 'controle_a_affecter', icon: '🏛️', sub: '9.1' },
+  { etape: 9, statut: 'controle_a_effectuer', label: t('step_controle_a_effectuer_label'), code: 'controle_a_effectuer', icon: '📑', sub: '9.2' },
+  { etape: 9, statut: 'controle_en_attente_pec', label: t('step_controle_en_attente_pec_label'), code: 'controle_en_attente_pec', icon: '🏛️', sub: '9.3' },
+  { etape: 10, statut: 'prete_pour_insertion_decret', label: t('step_prete_pour_insertion_decret_label'), code: 'prete_pour_insertion_decret', icon: '✅', sub: '10.7' },
+  { etape: 11, statut: 'inseree_dans_decret', label: t('step_inseree_dans_decret_label'), code: 'inseree_dans_decret', icon: '📜', sub: '11.1' },
+  { etape: 12, statut: 'decret_naturalisation_publie', label: t('step_decret_naturalisation_publie_label'), code: 'decret_naturalisation_publie', icon: '🇫🇷' }
 ];
 
 // ─────────────────────────────────────────────────────────────
@@ -436,15 +438,22 @@ export function getStatusExplanation(statutCode) {
   const info = STATUTS[code];
 
   if (info) {
-    return { ...info, found: true, code };
+    return {
+      ...info,
+      phase: t(info.phaseKey),
+      explication: t(info.explicationKey),
+      description: t(info.descriptionKey),
+      found: true,
+      code
+    };
   }
 
   return {
-    phase: "Statut inconnu",
-    explication: statutCode || "Non disponible",
+    phase: t("status_unknown_phase"),
+    explication: statutCode || t("status_unknown_explication"),
     etape: 0,
     rang: 0,
-    description: "Statut non répertorié. Contactez votre préfecture.",
+    description: t("status_unknown_description"),
     icon: "❓",
     found: false,
     code
@@ -453,7 +462,7 @@ export function getStatusExplanation(statutCode) {
 
 /** Formate une durée en jours */
 export function formatDuration(jours) {
-  if (jours === 0) return "aujourd'hui";
+  if (jours === 0) return t("duration_today");
   if (!jours || jours < 0) return "—";
 
   const annees = Math.floor(jours / 365);
@@ -461,10 +470,10 @@ export function formatDuration(jours) {
   const joursRestants = Math.floor((jours % 365) % 30);
 
   const parts = [];
-  if (annees > 0) parts.push(`${annees} an${annees > 1 ? 's' : ''}`);
-  if (mois > 0) parts.push(`${mois} mois`);
+  if (annees > 0) parts.push(annees > 1 ? t('duration_year_other', [annees.toString()]) : t('duration_year_one', [annees.toString()]));
+  if (mois > 0) parts.push(t('duration_month', [mois.toString()]));
   if (joursRestants > 0 || parts.length === 0) {
-    parts.push(`${joursRestants} jour${joursRestants > 1 ? 's' : ''}`);
+    parts.push(joursRestants > 1 ? t('duration_day_other', [joursRestants.toString()]) : t('duration_day_one', [joursRestants.toString()]));
   }
 
   return parts.join(', ');
@@ -492,7 +501,7 @@ export function daysSince(dateStr) {
 // Fuseau horaire français
 const TIMEZONE = 'Europe/Paris';
 
-/** Formate une date en français */
+/** Formate une date selon la locale */
 export function formatDate(dateStr, includeTime = false) {
   if (!dateStr) return "—";
   try {
@@ -511,7 +520,7 @@ export function formatDate(dateStr, includeTime = false) {
       options.minute = '2-digit';
     }
 
-    return date.toLocaleDateString('fr-FR', options);
+    return date.toLocaleDateString(getLocale(), options);
   } catch {
     return "—";
   }
@@ -519,7 +528,7 @@ export function formatDate(dateStr, includeTime = false) {
 
 /** Formate une date courte (ex: "1 janv., 14:30") */
 export function formatDateShort(date) {
-  return new Date(date).toLocaleString('fr-FR', {
+  return new Date(date).toLocaleString(getLocale(), {
     day: 'numeric',
     month: 'short',
     hour: '2-digit',
@@ -530,7 +539,7 @@ export function formatDateShort(date) {
 
 /** Formate un timestamp pour les logs (ex: "01/02/2026 14:30:45") */
 export function formatTimestamp(date = new Date()) {
-  return date.toLocaleString('fr-FR', {
+  return date.toLocaleString(getLocale(), {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
@@ -543,7 +552,7 @@ export function formatTimestamp(date = new Date()) {
 
 /** Formate l'heure seule (ex: "14:30:45") */
 export function formatTime(date = new Date()) {
-  return date.toLocaleTimeString('fr-FR', {
+  return date.toLocaleTimeString(getLocale(), {
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 3,
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjHcKjXopwPkpDO4yzntzQDXaLmxXroeXlp7Lq1co1ys/u5KdKCFHAe7Muj1I1MwYvU34iQgJOgrmJivGXa8OhfOrH14kqwXL31oX4FMPQIrQS99e/fh/fY+LlasFiV2cckJ3sUygprD8L2T1K4rqoAF4yJGhbjW9JK+dcKroRrnoaHBLEh7STgArWd9r/EPRL3klMpUU8ZF7atVSb9aFNrTf8D2E918LHb/92tVivF4kfkgsYzGXGgAEW+Pzjy+0tlszo7vuiJHd/XyX5AdP3rIHkIL7YUcoiXk400KR4G4NM+/dCnsSO5VZkJmpxOWjFKa6MNHTkpLg+2ZoSrvW/QIDAQAB",
-  "name": "ANEF Status Tracker",
+  "name": "__MSG_extName__",
   "version": "2.4.3",
-  "description": "Suivez votre statut de naturalisation ANEF en temps réel",
+  "description": "__MSG_extDescription__",
   "author": "ANEF Bot",
   "default_locale": "fr",
   "permissions": [

--- a/options/options.html
+++ b/options/options.html
@@ -13,7 +13,7 @@
       <div class="header-content">
         <div>
           <h1>ANEF Status Tracker</h1>
-          <p class="subtitle">Paramètres et historique</p>
+          <p class="subtitle" data-i18n="options_subtitle">Paramètres et historique</p>
         </div>
       </div>
     </header>
@@ -25,14 +25,14 @@
           <path d="M12 8v4l3 3"></path>
           <circle cx="12" cy="12" r="10"></circle>
         </svg>
-        Historique
+        <span data-i18n="options_tab_history">Historique</span>
       </button>
       <button class="tab" data-tab="settings">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
           <circle cx="12" cy="12" r="3"></circle>
           <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
         </svg>
-        Paramètres
+        <span data-i18n="options_tab_settings">Paramètres</span>
       </button>
       <button class="tab" data-tab="export">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -40,7 +40,7 @@
           <polyline points="7 10 12 15 17 10"></polyline>
           <line x1="12" y1="15" x2="12" y2="3"></line>
         </svg>
-        Export
+        <span data-i18n="options_tab_export">Export</span>
       </button>
       <button class="tab" data-tab="debug">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -48,7 +48,7 @@
           <path d="M2 17l10 5 10-5"></path>
           <path d="M2 12l10 5 10-5"></path>
         </svg>
-        Debug
+        <span data-i18n="options_tab_debug">Debug</span>
       </button>
     </nav>
 
@@ -58,14 +58,14 @@
       <section id="tab-history" class="tab-content active">
         <!-- Journal des vérifications du jour -->
         <div id="check-log-section" class="check-log-section hidden">
-          <h3 class="check-log-title">Vérifications du jour</h3>
+          <h3 class="check-log-title" data-i18n="options_check_log_title">Vérifications du jour</h3>
           <div id="check-log-list" class="check-log-list"></div>
         </div>
 
         <!-- Timeline des étapes (saisie manuelle) -->
         <div id="step-dates-section" class="step-dates-section hidden">
           <div class="section-header">
-            <h2>Mes dates d'étapes</h2>
+            <h2 data-i18n="options_step_dates_title">Mes dates d'étapes</h2>
             <div class="step-dates-actions">
               <button id="btn-pull-dates" class="btn btn-secondary btn-sm" title="Récupérer depuis la base de données">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -73,7 +73,7 @@
                   <polyline points="7 10 12 15 17 10"></polyline>
                   <line x1="12" y1="15" x2="12" y2="3"></line>
                 </svg>
-                Récupérer
+                <span data-i18n="options_pull_dates">Récupérer</span>
               </button>
               <button id="btn-save-dates" class="btn btn-primary btn-sm">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -81,23 +81,23 @@
                   <polyline points="17 21 17 13 7 13 7 21"></polyline>
                   <polyline points="7 3 7 8 15 8"></polyline>
                 </svg>
-                Enregistrer
+                <span data-i18n="options_save_dates">Enregistrer</span>
               </button>
             </div>
           </div>
-          <p class="step-dates-hint">Renseignez les dates de vos changements d'étape pour enrichir les statistiques communautaires.</p>
+          <p class="step-dates-hint" data-i18n="options_step_dates_hint">Renseignez les dates de vos changements d'étape pour enrichir les statistiques communautaires.</p>
           <div id="step-dates-timeline" class="step-dates-timeline"></div>
         </div>
 
         <div class="section-header">
-          <h2>Historique des statuts</h2>
+          <h2 data-i18n="options_history_title">Historique des statuts</h2>
         </div>
 
         <div id="history-list" class="history-list">
           <div class="empty-state">
             <span class="empty-icon">📊</span>
-            <p>Aucun historique disponible</p>
-            <p class="empty-hint">Visitez le site ANEF pour commencer à enregistrer votre historique.</p>
+            <p data-i18n="options_no_history">Aucun historique disponible</p>
+            <p class="empty-hint" data-i18n="options_no_history_hint">Visitez le site ANEF pour commencer à enregistrer votre historique.</p>
           </div>
         </div>
       </section>
@@ -107,25 +107,25 @@
         <h2>Paramètres</h2>
 
         <div class="settings-group">
-          <h3>Connexion automatique</h3>
-          <p class="settings-description">Enregistrez vos identifiants ANEF pour permettre l'actualisation automatique même si votre session a expiré.</p>
+          <h3 data-i18n="options_auto_login_title">Connexion automatique</h3>
+          <p class="settings-description" data-i18n="options_auto_login_desc">Enregistrez vos identifiants ANEF pour permettre l'actualisation automatique même si votre session a expiré.</p>
 
           <div class="credential-form">
             <div class="setting-item">
               <div class="setting-info">
-                <span class="setting-label">Numéro étranger</span>
-                <span class="setting-description">Votre identifiant de connexion ANEF</span>
+                <span class="setting-label" data-i18n="options_username_label">Numéro étranger</span>
+                <span class="setting-description" data-i18n="options_username_desc">Votre identifiant de connexion ANEF</span>
               </div>
-              <input type="text" id="setting-username" class="input" placeholder="Ex: 0123456789" autocomplete="username">
+              <input type="text" id="setting-username" class="input" placeholder="Ex: 0123456789" data-i18n-placeholder="options_username_placeholder" autocomplete="username">
             </div>
 
             <div class="setting-item">
               <div class="setting-info">
-                <span class="setting-label">Mot de passe</span>
+                <span class="setting-label" data-i18n="options_password_label">Mot de passe</span>
               </div>
               <div class="password-input-wrapper">
                 <input type="password" id="setting-password" class="input" placeholder="••••••••" autocomplete="current-password">
-                <button type="button" id="btn-toggle-password" class="btn-icon-small" title="Afficher/Masquer">
+                <button type="button" id="btn-toggle-password" class="btn-icon-small" title="Afficher/Masquer" data-i18n-title="options_toggle_password">
                   <svg id="icon-eye" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
                     <circle cx="12" cy="12" r="3"></circle>
@@ -140,7 +140,7 @@
 
             <div class="credential-status" id="credential-status">
               <span class="status-indicator" id="credential-indicator"></span>
-              <span id="credential-status-text">Aucun identifiant enregistré</span>
+              <span id="credential-status-text" data-i18n="options_no_credentials">Aucun identifiant enregistré</span>
             </div>
 
             <div class="credential-actions">
@@ -150,14 +150,14 @@
                   <polyline points="17 21 17 13 7 13 7 21"></polyline>
                   <polyline points="7 3 7 8 15 8"></polyline>
                 </svg>
-                Enregistrer
+                <span data-i18n="options_save">Enregistrer</span>
               </button>
               <button id="btn-clear-credentials" class="btn btn-danger btn-sm">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                   <polyline points="3 6 5 6 21 6"></polyline>
                   <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
                 </svg>
-                Supprimer
+                <span data-i18n="options_delete">Supprimer</span>
               </button>
             </div>
 
@@ -167,30 +167,30 @@
                 <line x1="12" y1="8" x2="12" y2="12"></line>
                 <line x1="12" y1="16" x2="12.01" y2="16"></line>
               </svg>
-              <span>Vos identifiants sont stockés localement sur votre appareil et ne sont jamais envoyés à des serveurs externes.</span>
+              <span data-i18n="options_credential_warning">Vos identifiants sont stockés localement sur votre appareil et ne sont jamais envoyés à des serveurs externes.</span>
             </div>
           </div>
         </div>
 
         <div class="settings-group">
-          <h3>Notifications</h3>
+          <h3 data-i18n="options_notifications_title">Notifications</h3>
 
           <label class="setting-item">
             <div class="setting-info">
-              <span class="setting-label">Activer les notifications</span>
-              <span class="setting-description">Recevoir une notification lors d'un changement de statut</span>
+              <span class="setting-label" data-i18n="options_notifications_label">Activer les notifications</span>
+              <span class="setting-description" data-i18n="options_notifications_desc">Recevoir une notification lors d'un changement de statut</span>
             </div>
             <input type="checkbox" id="setting-notifications" class="toggle">
           </label>
         </div>
 
         <div class="settings-group">
-          <h3>Vérification automatique</h3>
+          <h3 data-i18n="options_autocheck_title">Vérification automatique</h3>
 
           <label class="setting-item" id="auto-check-toggle-wrapper">
             <div class="setting-info">
-              <span class="setting-label">Vérifier automatiquement</span>
-              <span class="setting-description">Vérifie votre statut ~3 fois par jour en arrière-plan</span>
+              <span class="setting-label" data-i18n="options_autocheck_label">Vérifier automatiquement</span>
+              <span class="setting-description" data-i18n="options_autocheck_desc">Vérifie votre statut ~3 fois par jour en arrière-plan</span>
             </div>
             <input type="checkbox" id="setting-auto-check" class="toggle">
           </label>
@@ -208,7 +208,7 @@
               <line x1="12" y1="8" x2="12" y2="12"></line>
               <line x1="12" y1="16" x2="12.01" y2="16"></line>
             </svg>
-            <span>Des identifiants enregistrés sont nécessaires pour la vérification automatique.</span>
+            <span data-i18n="options_autocheck_no_creds">Des identifiants enregistrés sont nécessaires pour la vérification automatique.</span>
           </div>
 
           <div id="auto-check-suspended" class="auto-check-suspended hidden">
@@ -218,14 +218,14 @@
               <line x1="12" y1="17" x2="12.01" y2="17"></line>
             </svg>
             <div>
-              <span class="auto-check-suspended-text">Mot de passe ANEF expir&eacute;</span>
-              <button id="btn-resume-auto-check" class="btn btn-sm btn-secondary" style="margin-top:8px">R&eacute;initialiser</button>
+              <span class="auto-check-suspended-text" data-i18n="options_autocheck_password_expired">Mot de passe ANEF expir&eacute;</span>
+              <button id="btn-resume-auto-check" class="btn btn-sm btn-secondary" style="margin-top:8px" data-i18n="options_autocheck_reset">R&eacute;initialiser</button>
             </div>
           </div>
         </div>
 
         <div class="settings-group">
-          <h3>Statistiques communautaires</h3>
+          <h3 data-i18n="options_stats_title">Statistiques communautaires</h3>
 
           <div class="credential-warning">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -239,27 +239,27 @@
         </div>
 
         <div class="settings-group">
-          <h3>Général</h3>
+          <h3 data-i18n="options_general_title">Général</h3>
 
           <label class="setting-item">
             <div class="setting-info">
-              <span class="setting-label">Limite de l'historique</span>
-              <span class="setting-description">Nombre maximum d'entrées à conserver</span>
+              <span class="setting-label" data-i18n="options_history_limit_label">Limite de l'historique</span>
+              <span class="setting-description" data-i18n="options_history_limit_desc">Nombre maximum d'entrées à conserver</span>
             </div>
             <select id="setting-history-limit" class="select">
-              <option value="50">50 entrées</option>
-              <option value="100">100 entrées</option>
-              <option value="200">200 entrées</option>
-              <option value="500">500 entrées</option>
+              <option value="50" data-i18n="options_entries_50">50 entrées</option>
+              <option value="100" data-i18n="options_entries_100">100 entrées</option>
+              <option value="200" data-i18n="options_entries_200">200 entrées</option>
+              <option value="500" data-i18n="options_entries_500">500 entrées</option>
             </select>
           </label>
         </div>
 
         <div class="settings-actions">
-          <button id="btn-save-settings" class="btn btn-primary">
+          <button id="btn-save-settings" class="btn btn-primary" data-i18n="options_save_settings">
             Sauvegarder
           </button>
-          <button id="btn-reset-settings" class="btn btn-secondary">
+          <button id="btn-reset-settings" class="btn btn-secondary" data-i18n="options_reset_settings">
             Réinitialiser
           </button>
         </div>
@@ -267,24 +267,24 @@
 
       <!-- Export Tab -->
       <section id="tab-export" class="tab-content">
-        <h2>Exporter / Importer</h2>
+        <h2 data-i18n="options_export_title">Exporter / Importer</h2>
 
         <div class="export-section">
-          <h3>Exporter les données</h3>
-          <p>Téléchargez une sauvegarde de toutes vos données (historique, paramètres).</p>
+          <h3 data-i18n="options_export_data_title">Exporter les données</h3>
+          <p data-i18n="options_export_data_desc">Téléchargez une sauvegarde de toutes vos données (historique, paramètres).</p>
           <button id="btn-export" class="btn btn-primary">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
               <polyline points="7 10 12 15 17 10"></polyline>
               <line x1="12" y1="15" x2="12" y2="3"></line>
             </svg>
-            Exporter (JSON)
+            <span data-i18n="options_export_json">Exporter (JSON)</span>
           </button>
         </div>
 
         <div class="export-section">
-          <h3>Importer des données</h3>
-          <p>Restaurez vos données depuis un fichier de sauvegarde.</p>
+          <h3 data-i18n="options_import_title">Importer des données</h3>
+          <p data-i18n="options_import_desc">Restaurez vos données depuis un fichier de sauvegarde.</p>
           <input type="file" id="import-file" accept=".json" style="display: none;">
           <button id="btn-import" class="btn btn-secondary">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -292,13 +292,13 @@
               <polyline points="17 8 12 3 7 8"></polyline>
               <line x1="12" y1="3" x2="12" y2="15"></line>
             </svg>
-            Importer
+            <span data-i18n="options_import">Importer</span>
           </button>
         </div>
 
         <div class="export-section danger-zone">
-          <h3>Zone de danger</h3>
-          <p>Supprimer toutes les données de l'extension.</p>
+          <h3 data-i18n="options_danger_title">Zone de danger</h3>
+          <p data-i18n="options_danger_desc">Supprimer toutes les données de l'extension.</p>
           <button id="btn-clear-all" class="btn btn-danger">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <polyline points="3 6 5 6 21 6"></polyline>
@@ -306,7 +306,7 @@
               <line x1="10" y1="11" x2="10" y2="17"></line>
               <line x1="14" y1="11" x2="14" y2="17"></line>
             </svg>
-            Tout supprimer
+            <span data-i18n="options_delete_all">Tout supprimer</span>
           </button>
         </div>
       </section>
@@ -314,25 +314,25 @@
       <!-- Debug Tab -->
       <section id="tab-debug" class="tab-content">
         <div class="section-header">
-          <h2>Logs de debug</h2>
+          <h2 data-i18n="options_debug_title">Logs de debug</h2>
           <div class="debug-actions">
-            <button id="btn-refresh-logs" class="btn btn-secondary btn-sm">
+            <button id="btn-refresh-logs" class="btn btn-secondary btn-sm" data-i18n="options_refresh_logs">
               Actualiser
             </button>
-            <button id="btn-clear-logs" class="btn btn-danger btn-sm">
+            <button id="btn-clear-logs" class="btn btn-danger btn-sm" data-i18n="options_clear_logs">
               Effacer
             </button>
           </div>
         </div>
 
         <div class="debug-info">
-          <p>Ces logs aident à diagnostiquer les problèmes de l'extension.</p>
+          <p data-i18n="options_debug_info">Ces logs aident à diagnostiquer les problèmes de l'extension.</p>
         </div>
 
         <div id="logs-container" class="logs-container">
           <div class="empty-state">
             <span class="empty-icon">📋</span>
-            <p>Aucun log disponible</p>
+            <p data-i18n="options_no_logs">Aucun log disponible</p>
           </div>
         </div>
       </section>

--- a/options/options.js
+++ b/options/options.js
@@ -11,6 +11,7 @@
 
 import * as storage from '../lib/storage.js';
 import { getStatusExplanation, formatDate, formatDateShort, formatDuration, daysSince, formatSubStep, STEP_DEFAULTS } from '../lib/status-parser.js';
+import { t, translatePage, getLocale } from '../lib/i18n-helper.js';
 
 // ─────────────────────────────────────────────────────────────
 // Éléments DOM
@@ -78,6 +79,8 @@ const elements = {
 // ─────────────────────────────────────────────────────────────
 
 document.addEventListener('DOMContentLoaded', async () => {
+  translatePage();
+  document.title = t('options_page_title');
   initTabs();
   initVersion();
 
@@ -191,7 +194,7 @@ async function loadHistory() {
     lastCheckHtml = `
       <div class="last-check-banner">
         <span class="last-check-icon">🔄</span>
-        <span>Dernière vérification : <strong>${formatDate(lastCheck, true)}</strong></span>
+        <span>${t('options_last_check_banner')}<strong>${formatDate(lastCheck, true)}</strong></span>
       </div>
     `;
   }
@@ -201,8 +204,8 @@ async function loadHistory() {
       ${lastCheckHtml}
       <div class="empty-state">
         <span class="empty-icon">📊</span>
-        <p>Aucun historique disponible</p>
-        <p class="empty-hint">Visitez le site ANEF pour enregistrer votre historique.</p>
+        <p>${t('options_no_history')}</p>
+        <p class="empty-hint">${t('options_no_history_hint')}</p>
       </div>
     `;
     return;
@@ -223,13 +226,13 @@ async function loadHistory() {
           <div class="history-phase">${info.phase}</div>
           <code class="history-code">${item.statut}</code>
           <div class="history-date">
-            ${item.date_statut ? `Depuis le ${statusDate} <span class="duration-badge">${duration}</span>` : 'Date inconnue'}
+            ${item.date_statut ? `${t('options_since', [statusDate])} <span class="duration-badge">${duration}</span>` : t('options_date_unknown')}
           </div>
         </div>
         <div class="history-step">
-          <span class="step-label">étape</span>
+          <span class="step-label">${t('options_step_label')}</span>
           <span class="step-number">${formatSubStep(info.rang)}</span>
-          <span class="step-total">sur 12</span>
+          <span class="step-total">${t('options_step_total')}</span>
         </div>
       </div>
     `;
@@ -286,16 +289,16 @@ async function loadStepDates() {
     const stepRang = getStatusExplanation(step.statut).rang;
     const isFuture = !isCurrent && stepRang > currentRang;
     const itemClass = (isCurrent ? 'current ' : '') + (isFuture ? 'future ' : '') + (isAuto ? 'auto' : (dateValue ? 'filled' : ''));
-    const etapeLabel = step.sub ? `Étape ${step.sub}` : `Étape ${step.etape}`;
+    const etapeLabel = step.sub ? t('options_step_sub', [step.sub]) : t('options_step_sub', [step.etape.toString()]);
     const disabled = (isAuto || isLocked || isFuture) ? 'disabled' : '';
 
     let badgeHtml = '';
     if (hasManualOverride) {
-      badgeHtml = '<span class="step-date-badge manual">Rectifié</span>';
+      badgeHtml = `<span class="step-date-badge manual">${t('options_badge_rectified')}</span>`;
     } else if (isAuto) {
-      badgeHtml = '<span class="step-date-badge auto">Auto</span>';
+      badgeHtml = `<span class="step-date-badge auto">${t('options_badge_auto')}</span>`;
     } else if (dateValue) {
-      badgeHtml = '<span class="step-date-badge manual">Manuel</span>';
+      badgeHtml = `<span class="step-date-badge manual">${t('options_badge_manual')}</span>`;
     }
 
     // Bouton modifier pour les auto non verrouillés et non futurs
@@ -400,15 +403,15 @@ async function loadStepDates() {
     if (autoVal && curVal && curVal !== autoVal) {
       item.classList.remove('auto');
       item.classList.add('filled');
-      if (badge) { badge.textContent = 'Rectifié'; badge.className = 'step-date-badge manual'; }
+      if (badge) { badge.textContent = t('options_badge_rectified'); badge.className = 'step-date-badge manual'; }
     } else if (autoVal && (!curVal || curVal === autoVal)) {
       item.classList.remove('filled');
       item.classList.add('auto');
-      if (badge) { badge.textContent = 'Auto'; badge.className = 'step-date-badge auto'; }
+      if (badge) { badge.textContent = t('options_badge_auto'); badge.className = 'step-date-badge auto'; }
     } else if (curVal) {
       item.classList.add('filled');
       if (!badge) {
-        input.closest('.step-date-field').insertAdjacentHTML('afterend', '<span class="step-date-badge manual">Manuel</span>');
+        input.closest('.step-date-field').insertAdjacentHTML('afterend', `<span class="step-date-badge manual">${t('options_badge_manual')}</span>`);
       }
     }
     markUnsaved();
@@ -422,7 +425,7 @@ function markUnsaved() {
     banner = document.createElement('div');
     banner.id = 'unsaved-banner';
     banner.className = 'unsaved-banner';
-    banner.innerHTML = '<span class="unsaved-dot"></span> Modifications non enregistrées';
+    banner.innerHTML = `<span class="unsaved-dot"></span> ${t('options_unsaved')}`;
     elements.stepDatesTimeline.parentElement.insertBefore(banner, elements.stepDatesTimeline);
   }
   banner.classList.add('show');
@@ -444,7 +447,7 @@ async function handleSaveStepDates() {
     const val = input.dataset.value;
     if (val) {
       if (prevDate && val < prevDate) {
-        showToast('Les dates doivent être chronologiques', 'error');
+        showToast(t('options_dates_chronological'), 'error');
         input.focus();
         return;
       }
@@ -477,7 +480,7 @@ async function handleSaveStepDates() {
     } else if (!isoVal && existing) {
       // Champ vidé mais date existante → garder l'ancienne (pas de suppression)
       entries.push(existing);
-      showToast('Une date déjà enregistrée ne peut pas être supprimée', 'error');
+      showToast(t('options_date_cannot_delete'), 'error');
       return;
     }
   }
@@ -499,13 +502,13 @@ async function handleSaveStepDates() {
   await loadStepDates();
   await loadHistory();
   clearUnsaved();
-  showToast('Dates enregistrées et synchronisées', 'success');
+  showToast(t('options_dates_saved'), 'success');
 }
 
 async function handlePullStepDates() {
   try {
     elements.btnPullDates.disabled = true;
-    elements.btnPullDates.textContent = 'Chargement...';
+    elements.btnPullDates.textContent = t('options_loading');
 
     const result = await chrome.runtime.sendMessage({ type: 'PULL_STEP_DATES' });
 
@@ -517,12 +520,12 @@ async function handlePullStepDates() {
     if (result?.count > 0) {
       await loadStepDates();
       await loadHistory();
-      showToast(`${result.count} date(s) récupérée(s) depuis la base`, 'success');
+      showToast(t('options_dates_pulled', [result.count.toString()]), 'success');
     } else {
-      showToast('Aucune donnée trouvée dans la base', 'info');
+      showToast(t('options_no_data_found'), 'info');
     }
   } catch (e) {
-    showToast('Erreur de connexion', 'error');
+    showToast(t('options_connection_error'), 'error');
   } finally {
     elements.btnPullDates.disabled = false;
     elements.btnPullDates.innerHTML = `
@@ -531,7 +534,7 @@ async function handlePullStepDates() {
         <polyline points="7 10 12 15 17 10"></polyline>
         <line x1="12" y1="15" x2="12" y2="3"></line>
       </svg>
-      Récupérer`;
+      ${t('options_pull_dates')}`;
   }
 }
 
@@ -565,11 +568,11 @@ async function handleSaveSettings() {
   }
 
   await loadAutoCheckStatus();
-  showToast('Paramètres sauvegardés', 'success');
+  showToast(t('options_settings_saved'), 'success');
 }
 
 async function handleResetSettings() {
-  if (!confirm('Réinitialiser les paramètres par défaut ?')) return;
+  if (!confirm(t('options_confirm_reset'))) return;
 
   // Préserver le jitter unique de cette installation
   const currentSettings = await storage.getSettings();
@@ -585,7 +588,7 @@ async function handleResetSettings() {
   } catch (e) { /* ignore */ }
   await loadAutoCheckStatus();
 
-  showToast('Paramètres réinitialisés', 'success');
+  showToast(t('options_settings_reset'), 'success');
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -598,7 +601,7 @@ async function loadCredentialStatus() {
   if (hasCredentials) {
     elements.credentialIndicator?.classList.add('active');
     if (elements.credentialStatusText) {
-      elements.credentialStatusText.textContent = 'Identifiants enregistrés';
+      elements.credentialStatusText.textContent = t('options_credentials_saved');
     }
     const creds = await storage.getCredentials();
     if (creds?.username && elements.settingUsername) {
@@ -609,7 +612,7 @@ async function loadCredentialStatus() {
   } else {
     elements.credentialIndicator?.classList.remove('active');
     if (elements.credentialStatusText) {
-      elements.credentialStatusText.textContent = 'Aucun identifiant enregistré';
+      elements.credentialStatusText.textContent = t('options_no_credentials_saved');
     }
   }
 }
@@ -647,7 +650,7 @@ async function handleSaveCredentials() {
   }
 
   if (!username || !password) {
-    showToast('Veuillez remplir tous les champs', 'error');
+    showToast(t('options_fill_all_fields'), 'error');
     return;
   }
 
@@ -662,14 +665,14 @@ async function handleSaveCredentials() {
     } catch (e) { /* ignore */ }
     await loadAutoCheckStatus();
 
-    showToast('Identifiants enregistrés', 'success');
+    showToast(t('options_credentials_saved'), 'success');
   } catch (error) {
-    showToast('Erreur lors de la sauvegarde', 'error');
+    showToast(t('options_save_error'), 'error');
   }
 }
 
 async function handleClearCredentials() {
-  if (!confirm('Supprimer vos identifiants ?')) return;
+  if (!confirm(t('options_confirm_delete_creds'))) return;
 
   try {
     await storage.clearCredentials();
@@ -691,9 +694,9 @@ async function handleClearCredentials() {
       await loadAutoCheckStatus();
     }
 
-    showToast('Identifiants supprimés', 'success');
+    showToast(t('options_credentials_deleted'), 'success');
   } catch (error) {
-    showToast('Erreur lors de la suppression', 'error');
+    showToast(t('options_delete_error'), 'error');
   }
 }
 
@@ -721,7 +724,7 @@ async function loadAutoCheckStatus() {
       if (passwordExpired) {
         elements.autoCheckSuspended.classList.remove('hidden');
         const suspendedText = elements.autoCheckSuspended.querySelector('.auto-check-suspended-text, span');
-        if (suspendedText) suspendedText.textContent = 'Mot de passe ANEF expiré — renouveler sur le portail';
+        if (suspendedText) suspendedText.textContent = t('options_password_expired_msg');
       } else {
         elements.autoCheckSuspended.classList.add('hidden');
       }
@@ -736,12 +739,12 @@ async function loadAutoCheckStatus() {
 
         if (passwordExpired) {
           elements.autoCheckDot.className = 'auto-check-dot error';
-          elements.autoCheckStatusText.textContent = 'Mot de passe expiré';
+          elements.autoCheckStatusText.textContent = t('options_password_expired_short');
         } else if (consecutiveFailures > 0 && nextAlarm) {
           elements.autoCheckDot.className = 'auto-check-dot warning';
           const nextDate = new Date(nextAlarm);
           const diffMin = Math.round((nextDate - Date.now()) / 60000);
-          elements.autoCheckStatusText.textContent = `${consecutiveFailures} échec(s) · prochaine tentative dans ~${diffMin} min`;
+          elements.autoCheckStatusText.textContent = t('options_failures_next', [consecutiveFailures.toString(), diffMin.toString()]);
         } else if (nextAlarm) {
           elements.autoCheckDot.className = 'auto-check-dot active';
           const nextDate = new Date(nextAlarm);
@@ -749,17 +752,17 @@ async function loadAutoCheckStatus() {
           const diffMin = Math.round((nextDate - now) / 60000);
 
           if (diffMin <= 0) {
-            elements.autoCheckStatusText.textContent = 'Prochaine vérification imminente';
+            elements.autoCheckStatusText.textContent = t('options_next_check_imminent');
           } else if (diffMin < 60) {
-            elements.autoCheckStatusText.textContent = `Prochaine vérification dans ~${diffMin} min`;
+            elements.autoCheckStatusText.textContent = t('options_next_check_min', [diffMin.toString()]);
           } else {
             const hours = Math.floor(diffMin / 60);
             const mins = diffMin % 60;
-            elements.autoCheckStatusText.textContent = `Prochaine vérification dans ~${hours}h${mins > 0 ? mins.toString().padStart(2, '0') : ''}`;
+            elements.autoCheckStatusText.textContent = t('options_next_check_hours', [hours.toString(), mins > 0 ? mins.toString().padStart(2, '0') : '']);
           }
         } else {
           elements.autoCheckDot.className = 'auto-check-dot';
-          elements.autoCheckStatusText.textContent = 'En attente de programmation';
+          elements.autoCheckStatusText.textContent = t('options_waiting_schedule');
         }
       }
     }
@@ -779,9 +782,9 @@ async function handleResumeAutoCheck() {
     }
     await chrome.runtime.sendMessage({ type: 'SETTINGS_CHANGED' });
     await loadAutoCheckStatus();
-    showToast('Vérification automatique réactivée', 'success');
+    showToast(t('options_autocheck_reactivated'), 'success');
   } catch (e) {
-    showToast('Erreur lors de la réactivation', 'error');
+    showToast(t('options_reactivation_error'), 'error');
   }
 }
 
@@ -805,13 +808,13 @@ async function loadCheckLog() {
 
     elements.checkLogSection?.classList.remove('hidden');
 
-    const typeLabels = { auto: 'Auto', manual: 'Manuel', retry: 'Retry' };
+    const typeLabels = { auto: t('options_badge_auto'), manual: t('options_badge_manual'), retry: 'Retry' };
     const typeClasses = { auto: 'badge-auto', manual: 'badge-manual', retry: 'badge-retry' };
 
     elements.checkLogList.innerHTML = todayEntries
       .sort((a, b) => b.timestamp.localeCompare(a.timestamp))
       .map(entry => {
-        const time = new Date(entry.timestamp).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
+        const time = new Date(entry.timestamp).toLocaleTimeString(getLocale(), { hour: '2-digit', minute: '2-digit' });
         const badge = `<span class="check-log-badge ${typeClasses[entry.type] || ''}">${typeLabels[entry.type] || entry.type}</span>`;
         const icon = entry.success ? '<span class="check-log-icon success">✓</span>' : '<span class="check-log-icon error">✗</span>';
         const duration = entry.duration != null ? `<span class="check-log-duration">${entry.duration}s</span>` : '';
@@ -840,9 +843,9 @@ async function handleExport() {
     a.click();
 
     URL.revokeObjectURL(url);
-    showToast('Export réussi', 'success');
+    showToast(t('options_export_success'), 'success');
   } catch (error) {
-    showToast('Erreur lors de l\'export', 'error');
+    showToast(t('options_export_error'), 'error');
   }
 }
 
@@ -852,7 +855,7 @@ async function handleImport(event) {
 
   try {
     const data = JSON.parse(await file.text());
-    if (!data.exportDate) throw new Error('Fichier invalide');
+    if (!data.exportDate) throw new Error(t('options_invalid_file'));
 
     await storage.importData(data);
     await loadHistory();
@@ -864,16 +867,16 @@ async function handleImport(event) {
     } catch (e) { /* ignore */ }
     await loadAutoCheckStatus();
 
-    showToast('Import réussi', 'success');
+    showToast(t('options_import_success'), 'success');
   } catch (error) {
-    showToast('Erreur lors de l\'import', 'error');
+    showToast(t('options_import_error'), 'error');
   }
 
   event.target.value = '';
 }
 
 async function handleClearAll() {
-  if (!confirm('Supprimer toutes les données (historique, paramètres) ?\nVos identifiants de connexion seront conservés.\nCette action est irréversible.')) return;
+  if (!confirm(t('options_confirm_delete_all'))) return;
 
   await storage.clearExceptCredentials();
   await loadHistory();
@@ -886,7 +889,7 @@ async function handleClearAll() {
   await loadAutoCheckStatus();
   await loadCheckLog();
 
-  showToast('Données supprimées (identifiants conservés)', 'success');
+  showToast(t('options_data_deleted'), 'success');
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -901,7 +904,7 @@ async function loadLogs() {
       elements.logsContainer.innerHTML = `
         <div class="empty-state">
           <span class="empty-icon">📋</span>
-          <p>Aucun log disponible</p>
+          <p>${t('options_no_logs')}</p>
         </div>
       `;
       return;
@@ -923,7 +926,7 @@ async function loadLogs() {
     elements.logsContainer.innerHTML = `
       <div class="empty-state">
         <span class="empty-icon">❌</span>
-        <p>Erreur de chargement</p>
+        <p>${t('options_log_error')}</p>
       </div>
     `;
   }
@@ -933,7 +936,7 @@ async function handleClearLogs() {
   try {
     await chrome.runtime.sendMessage({ type: 'CLEAR_LOGS' });
     await loadLogs();
-    showToast('Logs effacés', 'success');
+    showToast(t('options_logs_cleared'), 'success');
   } catch (error) {
     showToast('Erreur', 'error');
   }

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -14,7 +14,7 @@
         <h1>ANEF Status <span id="version" class="version">v1.0</span></h1>
       </div>
       <div class="header-actions">
-        <button id="btn-settings" class="btn-icon" title="Paramètres">
+        <button id="btn-settings" class="btn-icon" title="Paramètres" data-i18n-title="popup_settings_title">
           <svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
@@ -29,13 +29,13 @@
         <div class="card-icon-wrapper maintenance">
           <span class="card-icon">🔧</span>
         </div>
-        <h2>Site en maintenance</h2>
-        <p>Le site ANEF est actuellement en maintenance. Veuillez réessayer plus tard.</p>
+        <h2 data-i18n="popup_maintenance_title">Site en maintenance</h2>
+        <p data-i18n="popup_maintenance_desc">Le site ANEF est actuellement en maintenance. Veuillez réessayer plus tard.</p>
         <button id="btn-retry" class="btn btn-primary">
           <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
           </svg>
-          <span>Réessayer</span>
+          <span data-i18n="popup_retry">Réessayer</span>
         </button>
       </div>
     </div>
@@ -46,10 +46,10 @@
         <div class="card-icon-wrapper warning">
           <span class="card-icon">🔑</span>
         </div>
-        <h2>Mot de passe expir&eacute;</h2>
-        <p>Votre mot de passe ANEF a expir&eacute;. Connectez-vous sur le portail ANEF pour le renouveler, puis relancez une v&eacute;rification.</p>
+        <h2 data-i18n="popup_password_expired_title">Mot de passe expir&eacute;</h2>
+        <p data-i18n="popup_password_expired_desc">Votre mot de passe ANEF a expir&eacute;. Connectez-vous sur le portail ANEF pour le renouveler, puis relancez une v&eacute;rification.</p>
         <button id="btn-renew-password" class="btn btn-primary">
-          <span>Renouveler sur ANEF</span>
+          <span data-i18n="popup_renew_password">Renouveler sur ANEF</span>
           <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
           </svg>
@@ -63,13 +63,13 @@
         <div class="card-icon-wrapper warning">
           <span class="card-icon">🔒</span>
         </div>
-        <h2>Session expirée</h2>
-        <p>Votre session ANEF a expiré. Reconnectez-vous pour actualiser votre statut.</p>
-        <p class="hint-text">
+        <h2 data-i18n="popup_session_expired_title">Session expirée</h2>
+        <p data-i18n="popup_session_expired_desc">Votre session ANEF a expiré. Reconnectez-vous pour actualiser votre statut.</p>
+        <p class="hint-text" data-i18n-html="popup_login_hint">
           <a href="#" id="link-save-credentials" class="link-settings">Enregistrez vos identifiants</a> pour une connexion automatique.
         </p>
         <button id="btn-login" class="btn btn-primary">
-          <span>Se connecter à ANEF</span>
+          <span data-i18n="popup_login">Se connecter à ANEF</span>
           <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
           </svg>
@@ -83,10 +83,10 @@
         <div class="card-icon-wrapper info">
           <span class="card-icon">📊</span>
         </div>
-        <h2>Aucune donnée</h2>
-        <p>Visitez votre espace ANEF pour récupérer votre statut.</p>
+        <h2 data-i18n="popup_no_data_title">Aucune donnée</h2>
+        <p data-i18n="popup_no_data_desc">Visitez votre espace ANEF pour récupérer votre statut.</p>
         <button id="btn-check" class="btn btn-primary">
-          <span>Vérifier mon statut</span>
+          <span data-i18n="popup_check_status">Vérifier mon statut</span>
           <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
           </svg>
@@ -98,23 +98,23 @@
     <div id="view-loading" class="view hidden">
       <div class="card card-loading">
         <div class="spinner"></div>
-        <h2 id="loading-title">Actualisation...</h2>
-        <p id="loading-message">Ouverture de la page ANEF...</p>
+        <h2 id="loading-title" data-i18n="popup_loading_title">Actualisation...</h2>
+        <p id="loading-message" data-i18n="popup_loading_message">Ouverture de la page ANEF...</p>
         <div class="loading-steps">
           <div class="loading-step" id="step-open">
             <span class="step-icon">1</span>
-            <span class="step-text">Ouverture page</span>
+            <span class="step-text" data-i18n="popup_step_open">Ouverture page</span>
           </div>
           <div class="loading-step" id="step-load">
             <span class="step-icon">2</span>
-            <span class="step-text">Chargement</span>
+            <span class="step-text" data-i18n="popup_step_load">Chargement</span>
           </div>
           <div class="loading-step" id="step-data">
             <span class="step-icon">3</span>
-            <span class="step-text">Récupération</span>
+            <span class="step-text" data-i18n="popup_step_data">Récupération</span>
           </div>
         </div>
-        <p class="loading-hint">Cette opération peut prendre jusqu'à 45 secondes</p>
+        <p class="loading-hint" data-i18n="popup_loading_hint">Cette opération peut prendre jusqu'à 45 secondes</p>
 
         <!-- Citations sur la patience -->
         <div class="quote-container">
@@ -138,7 +138,7 @@
           </div>
           <div class="status-info">
             <span class="status-phase" id="status-phase">—</span>
-            <span class="status-step" id="status-step">Étape ?/12</span>
+            <span class="status-step" id="status-step" data-i18n="popup_step_default">Étape ?/12</span>
           </div>
         </div>
 
@@ -165,19 +165,19 @@
             <div class="progress-fill" id="progress-fill"></div>
           </div>
           <div class="progress-labels">
-            <span>Dépôt</span>
-            <span>Décret</span>
+            <span data-i18n="popup_progress_start">Dépôt</span>
+            <span data-i18n="popup_progress_end">Décret</span>
           </div>
         </div>
 
         <!-- Dates -->
         <div class="status-dates">
           <div class="status-date-row">
-            <span class="status-date-label">📅 Statut depuis</span>
+            <span class="status-date-label" data-i18n="popup_status_since">📅 Statut depuis</span>
             <span class="status-date-value" id="status-date">—</span>
           </div>
           <div class="status-date-row">
-            <span class="status-date-label">🔄 Dernière MAJ</span>
+            <span class="status-date-label" data-i18n="popup_last_update_label">🔄 Dernière MAJ</span>
             <span class="status-date-value" id="status-last-check">—</span>
           </div>
         </div>
@@ -188,8 +188,8 @@
         <div class="step-dates-alert-content">
           <span class="step-dates-alert-pulse"></span>
           <span class="step-dates-alert-text">
-            <strong>Historique incomplet</strong>
-            <span class="step-dates-alert-sub">Renseignez vos dates d'étapes passées pour enrichir les statistiques</span>
+            <strong data-i18n="popup_history_incomplete_title">Historique incomplet</strong>
+            <span class="step-dates-alert-sub" data-i18n="popup_history_incomplete_desc">Renseignez vos dates d'étapes passées pour enrichir les statistiques</span>
           </span>
         </div>
         <span class="step-dates-alert-arrow">→</span>
@@ -201,13 +201,13 @@
           <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
           </svg>
-          <span>Actualiser</span>
+          <span data-i18n="popup_refresh">Actualiser</span>
         </button>
-        <button id="btn-download" class="btn btn-secondary" title="Exporter le suivi en image">
+        <button id="btn-download" class="btn btn-secondary" title="Exporter le suivi en image" data-i18n-title="popup_share_title">
           <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"></path>
           </svg>
-          <span>Partager</span>
+          <span data-i18n="popup_share">Partager</span>
         </button>
       </div>
 
@@ -216,19 +216,19 @@
         <div class="stats-cards">
           <div id="stat-depot" class="stat-card">
             <span class="stat-icon">📅</span>
-            <span class="stat-label">Dépôt</span>
+            <span class="stat-label" data-i18n="popup_stat_depot">Dépôt</span>
             <span class="stat-value" id="stat-depot-value">—</span>
             <span class="stat-date" id="stat-depot-date">—</span>
           </div>
           <div id="stat-entretien" class="stat-card">
             <span class="stat-icon">🗣️</span>
-            <span class="stat-label">Entretien</span>
+            <span class="stat-label" data-i18n="popup_stat_entretien">Entretien</span>
             <span class="stat-value" id="stat-entretien-value">—</span>
             <span class="stat-date" id="stat-entretien-date">—</span>
           </div>
           <div id="stat-statut-age" class="stat-card">
             <span class="stat-icon">⏱️</span>
-            <span class="stat-label">Dernière MAJ</span>
+            <span class="stat-label" data-i18n="popup_stat_last_update">Dernière MAJ</span>
             <span class="stat-value" id="stat-statut-age-value">—</span>
             <span class="stat-date" id="stat-statut-age-date">—</span>
           </div>
@@ -239,27 +239,27 @@
       <div id="details-section" class="details-section hidden">
         <div class="details-grid">
           <div id="detail-dossier-id" class="detail-chip hidden">
-            <span class="detail-chip-label">Dossier</span>
+            <span class="detail-chip-label" data-i18n="popup_detail_dossier">Dossier</span>
             <span class="detail-chip-value" id="detail-dossier-id-value">—</span>
           </div>
           <div id="detail-numero-national" class="detail-chip hidden">
-            <span class="detail-chip-label">N° National</span>
+            <span class="detail-chip-label" data-i18n="popup_detail_national">N° National</span>
             <span class="detail-chip-value" id="detail-numero-national-value">—</span>
           </div>
           <div id="detail-prefecture" class="detail-chip hidden">
-            <span class="detail-chip-label">Préfecture</span>
+            <span class="detail-chip-label" data-i18n="popup_detail_prefecture">Préfecture</span>
             <span class="detail-chip-value" id="detail-prefecture-value">—</span>
           </div>
           <div id="detail-type-demande" class="detail-chip hidden">
-            <span class="detail-chip-label">Type</span>
+            <span class="detail-chip-label" data-i18n="popup_detail_type">Type</span>
             <span class="detail-chip-value" id="detail-type-demande-value">—</span>
           </div>
           <div id="detail-entretien-lieu" class="detail-chip hidden">
-            <span class="detail-chip-label">Lieu</span>
+            <span class="detail-chip-label" data-i18n="popup_detail_location">Lieu</span>
             <span class="detail-chip-value" id="detail-entretien-lieu-value">—</span>
           </div>
           <div id="detail-decret" class="detail-chip detail-chip-success detail-chip-wide hidden">
-            <span class="detail-chip-label">🎉 Décret</span>
+            <span class="detail-chip-label" data-i18n="popup_detail_decree">🎉 Décret</span>
             <span class="detail-chip-value" id="detail-decret-value">—</span>
           </div>
         </div>
@@ -267,7 +267,7 @@
 
       <!-- Dernière vérification -->
       <div class="last-check">
-        Dernière vérification : <span id="last-check-date">—</span>
+        <span data-i18n="popup_last_check">Dernière vérification :</span> <span id="last-check-date">—</span>
       </div>
     </div>
 
@@ -277,7 +277,7 @@
         <span class="auto-check-banner-dot" id="auto-check-dot"></span>
         <span class="auto-check-banner-text" id="auto-check-next-text">—</span>
       </div>
-      <a href="#" id="auto-check-settings-link" class="auto-check-banner-link" title="Modifier dans les paramètres">
+      <a href="#" id="auto-check-settings-link" class="auto-check-banner-link" title="Modifier dans les paramètres" data-i18n-title="popup_autocheck_settings">
         <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
@@ -289,8 +289,8 @@
     <a id="link-stats" href="https://letranger-dev.github.io/anef-extension/" target="_blank" class="stats-banner">
       <span class="stats-banner-icon">📊</span>
       <span class="stats-banner-text">
-        <span class="stats-banner-title">Statistiques communautaires</span>
-        <span class="stats-banner-hint">Donnees 100% anonymes — Comparez votre progression</span>
+        <span class="stats-banner-title" data-i18n="popup_stats_link_title">Statistiques communautaires</span>
+        <span class="stats-banner-hint" data-i18n="popup_stats_link_desc">Donnees 100% anonymes — Comparez votre progression</span>
       </span>
       <svg class="stats-banner-arrow" width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -9,24 +9,15 @@
 
 import { getStatusExplanation, formatDuration, formatDate, formatDateShort, formatTimestamp, daysSince, isPositiveStatus, isNegativeStatus, formatSubStep, STEP_DEFAULTS } from '../lib/status-parser.js';
 import { downloadLogs } from '../lib/logger.js';
+import { t, translatePage, getLocale } from '../lib/i18n-helper.js';
 // ─────────────────────────────────────────────────────────────
 // Citations sur la patience
 // ─────────────────────────────────────────────────────────────
 
-const QUOTES = [
-  { text: "La patience est la clé du bien-être.", author: "Mohammed ﷺ" },
-  { text: "Tout vient à point à qui sait attendre.", author: "Proverbe français" },
-  { text: "La patience est amère, mais son fruit est doux.", author: "Jean-Jacques Rousseau" },
-  { text: "Adoptez le rythme de la nature : son secret est la patience.", author: "Ralph Waldo Emerson" },
-  { text: "La patience est l'art d'espérer.", author: "Luc de Clapiers" },
-  { text: "Ce qui est différé n'est pas perdu.", author: "Proverbe italien" },
-  { text: "Les grandes œuvres naissent de la patience.", author: "Gustave Flaubert" },
-  { text: "La patience et le temps font plus que force ni que rage.", author: "Jean de La Fontaine" },
-  { text: "Qui va lentement va sûrement.", author: "Proverbe latin" },
-  { text: "La persévérance vient à bout de tout.", author: "Proverbe français" },
-  { text: "Un voyage de mille lieues commence par un premier pas.", author: "Lao Tseu" },
-  { text: "L'attente est déjà la moitié du bonheur.", author: "Proverbe chinois" }
-];
+const QUOTES = Array.from({ length: 12 }, (_, i) => ({
+  text: t(`quote_${i + 1}_text`),
+  author: t(`quote_${i + 1}_author`)
+}));
 
 let quoteInterval = null;
 let currentQuoteIndex = 0;
@@ -157,6 +148,7 @@ function initializeElements() {
 
 document.addEventListener('DOMContentLoaded', async () => {
   initializeElements();
+  translatePage();
 
   // Afficher la version
   const manifest = chrome.runtime.getManifest();
@@ -300,7 +292,7 @@ function displayStatus(statusData, apiData, lastCheck) {
   // Icône et phase
   if (elements.statusIcon) elements.statusIcon.textContent = statusInfo.icon || '📋';
   if (elements.statusPhase) elements.statusPhase.textContent = statusInfo.phase;
-  if (elements.statusStep) elements.statusStep.textContent = `Étape ${formatSubStep(statusInfo.rang)}/12`;
+  if (elements.statusStep) elements.statusStep.textContent = t('popup_step_format', [formatSubStep(statusInfo.rang)]);
 
   // Code et description
   if (elements.statusCode) elements.statusCode.textContent = statut;
@@ -328,7 +320,7 @@ function displayStatus(statusData, apiData, lastCheck) {
       if (earliestDate) {
         const days = daysSince(earliestDate);
         const duration = formatDuration(days);
-        elements.statusDate.textContent = `${formatDate(earliestDate)} (${days === 0 ? "aujourd'hui" : 'il y a ' + duration})`;
+        elements.statusDate.textContent = `${formatDate(earliestDate)} (${days === 0 ? t('time_today') : t('time_ago', [duration])})`;
       } else {
         elements.statusDate.textContent = '—';
       }
@@ -392,11 +384,11 @@ function displayTemporalStats(statusData, apiData) {
     if (isPast) {
       const days = daysSince(dateEntretien);
       elements.statEntretienValue.textContent = days === 0
-        ? "Aujourd'hui"
-        : `Il y a ${formatDuration(days)}`;
+        ? t('interview_today')
+        : t('interview_ago', [formatDuration(days)]);
     } else {
       const days = Math.ceil((entretienDateObj - now) / 86400000);
-      elements.statEntretienValue.textContent = `Dans ${formatDuration(days)}`;
+      elements.statEntretienValue.textContent = t('time_in', [formatDuration(days)]);
     }
     elements.statEntretienDate.textContent = formatDate(dateEntretien, true);
     elements.statEntretien.classList.remove('hidden');
@@ -491,7 +483,7 @@ function displayLastCheck(lastCheck, lastCheckAttempt) {
       elements.lastCheckDate.textContent = formatDateShort(lastCheck) + ' ';
       const span = document.createElement('span');
       span.className = 'last-check-attempt';
-      span.textContent = '(tentative ' + formatDateShort(lastCheckAttempt.timestamp) + ')';
+      span.textContent = '(' + t('popup_attempt', [formatDateShort(lastCheckAttempt.timestamp)]) + ')';
       elements.lastCheckDate.appendChild(span);
     } else {
       elements.lastCheckDate.textContent = formatDateShort(lastCheck);
@@ -499,10 +491,10 @@ function displayLastCheck(lastCheck, lastCheckAttempt) {
   } else if (lastCheckAttempt) {
     const span = document.createElement('span');
     span.className = 'last-check-attempt';
-    span.textContent = 'Tentative ' + formatDateShort(lastCheckAttempt.timestamp);
+    span.textContent = t('popup_attempt_prefix', [formatDateShort(lastCheckAttempt.timestamp)]);
     elements.lastCheckDate.appendChild(span);
   } else {
-    elements.lastCheckDate.textContent = 'Jamais';
+    elements.lastCheckDate.textContent = t('popup_never');
   }
 }
 
@@ -527,25 +519,25 @@ async function loadAutoCheckNext() {
 
     if (info.passwordExpired) {
       container.classList.add('warning');
-      text.textContent = 'Mot de passe ANEF expiré · renouveler sur le portail';
+      text.textContent = t('popup_password_expired_banner');
     } else if (!info.hasCredentials) {
       container.classList.add('warning');
-      text.textContent = 'Vérification auto activée · identifiants requis';
+      text.textContent = t('popup_autocheck_creds_required');
     } else if (info.nextAlarm) {
       const diffMin = Math.round((info.nextAlarm - Date.now()) / 60000);
       let delai;
       if (diffMin <= 0) {
-        delai = 'imminente';
+        delai = t('popup_autocheck_imminent');
       } else if (diffMin < 60) {
-        delai = `dans ~${diffMin} min`;
+        delai = t('popup_autocheck_minutes', [diffMin.toString()]);
       } else {
         const hours = Math.floor(diffMin / 60);
         const mins = diffMin % 60;
-        delai = `dans ~${hours}h${mins > 0 ? mins.toString().padStart(2, '0') : ''}`;
+        delai = t('popup_autocheck_hours', [hours.toString(), mins > 0 ? mins.toString().padStart(2, '0') : '']);
       }
-      text.textContent = `Vérification auto activée · prochaine ${delai}`;
+      text.textContent = t('popup_autocheck_next', [delai]);
     } else {
-      text.textContent = 'Vérification auto activée';
+      text.textContent = t('popup_autocheck_enabled');
     }
   } catch (e) {
     console.warn('[Popup] Erreur chargement auto-check info:', e);
@@ -575,24 +567,24 @@ function updateLoadingStep(step) {
   switch (step) {
     case 1:
       stepOpen?.classList.add('active');
-      if (loadingMessage) loadingMessage.textContent = 'Ouverture de la page ANEF...';
+      if (loadingMessage) loadingMessage.textContent = t('popup_loading_step1');
       break;
     case 2:
       stepOpen?.classList.add('done');
       stepLoad?.classList.add('active');
-      if (loadingMessage) loadingMessage.textContent = 'Chargement de la page...';
+      if (loadingMessage) loadingMessage.textContent = t('popup_loading_step2');
       break;
     case 3:
       stepOpen?.classList.add('done');
       stepLoad?.classList.add('done');
       stepData?.classList.add('active');
-      if (loadingMessage) loadingMessage.textContent = 'Récupération des données...';
+      if (loadingMessage) loadingMessage.textContent = t('popup_loading_step3');
       break;
     case 4:
       stepOpen?.classList.add('done');
       stepLoad?.classList.add('done');
       stepData?.classList.add('done');
-      if (loadingMessage) loadingMessage.textContent = 'Terminé !';
+      if (loadingMessage) loadingMessage.textContent = t('popup_loading_step4');
       break;
   }
 }
@@ -707,10 +699,10 @@ async function downloadStatusImage() {
     // Date et heure
     const now = new Date();
     const dateStr = formatDate(now);
-    const timeStr = now.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit', timeZone: 'Europe/Paris' });
+    const timeStr = now.toLocaleTimeString(getLocale(), { hour: '2-digit', minute: '2-digit', timeZone: 'Europe/Paris' });
     ctx.font = '11px system-ui, -apple-system, sans-serif';
     ctx.fillStyle = 'rgba(255,255,255,0.8)';
-    ctx.fillText(`${dateStr} à ${timeStr}`, 20, 42);
+    ctx.fillText(`${dateStr} ${t('canvas_date_at')} ${timeStr}`, 20, 42);
 
     // Carte principale
     const cardY = 68;
@@ -744,7 +736,7 @@ async function downloadStatusImage() {
     ctx.fill();
     ctx.fillStyle = bleuFrance;
     ctx.font = '11px system-ui, -apple-system, sans-serif';
-    ctx.fillText(`Étape ${formatSubStep(statusInfo.rang)}/12`, 46, cardY + 48);
+    ctx.fillText(t('popup_step_format', [formatSubStep(statusInfo.rang)]), 46, cardY + 48);
 
     // Badge code statut
     ctx.font = '11px Monaco, Consolas, monospace';
@@ -782,9 +774,9 @@ async function downloadStatusImage() {
     // Labels progression
     ctx.fillStyle = '#94a3b8';
     ctx.font = '9px system-ui, -apple-system, sans-serif';
-    ctx.fillText('Dépôt', 36, progressY + 20);
+    ctx.fillText(t('popup_progress_start'), 36, progressY + 20);
     ctx.textAlign = 'right';
-    ctx.fillText('Décret', 36 + progressWidth, progressY + 20);
+    ctx.fillText(t('popup_progress_end'), 36 + progressWidth, progressY + 20);
     ctx.textAlign = 'left';
 
     // Section stats
@@ -802,25 +794,25 @@ async function downloadStatusImage() {
     const startX = (width - totalStatsWidth) / 2;
 
     if (apiData?.dateDepot) {
-      drawStatCard(ctx, startX + statIndex * (statWidth + statGap), statsY, statWidth, 'DÉPÔT', formatDuration(daysSince(apiData.dateDepot)), bleuFrance);
+      drawStatCard(ctx, startX + statIndex * (statWidth + statGap), statsY, statWidth, t('canvas_depot'), formatDuration(daysSince(apiData.dateDepot)), bleuFrance);
       statIndex++;
     }
 
     if (apiData?.dateEntretien) {
       const entretienDate = new Date(apiData.dateEntretien);
       const isPast = entretienDate < new Date();
-      const label = isPast ? 'ENTRETIEN' : 'ENTRETIEN PRÉVU';
+      const label = isPast ? t('canvas_entretien') : t('canvas_entretien_planned');
       const dateFormatted = formatDate(apiData.dateEntretien, true);
       const entretienDays = daysSince(apiData.dateEntretien);
       const duration = isPast
-        ? (entretienDays === 0 ? "Aujourd'hui" : `Il y a ${formatDuration(entretienDays)}`)
-        : `Dans ${formatDuration(Math.ceil((entretienDate - new Date()) / 86400000))}`;
+        ? (entretienDays === 0 ? t('interview_today') : t('interview_ago', [formatDuration(entretienDays)]))
+        : t('time_in', [formatDuration(Math.ceil((entretienDate - new Date()) / 86400000))]);
       drawStatCard(ctx, startX + statIndex * (statWidth + statGap), statsY, statWidth, label, `${dateFormatted} (${duration})`, bleuFrance);
       statIndex++;
     }
 
     if (lastStatus.date_statut) {
-      drawStatCard(ctx, startX + statIndex * (statWidth + statGap), statsY, statWidth, 'DERNIÈRE MAJ', formatDuration(daysSince(lastStatus.date_statut)), bleuFrance);
+      drawStatCard(ctx, startX + statIndex * (statWidth + statGap), statsY, statWidth, t('canvas_last_update'), formatDuration(daysSince(lastStatus.date_statut)), bleuFrance);
     }
 
     // Footer tricolore


### PR DESCRIPTION
## Summary

- Adds `_locales/en/messages.json` with 366 English translations for all user-facing strings
- Expands `_locales/fr/messages.json` from 2 to 366 keys (popup, options, status dictionary, notifications, duration labels)
- Adds `lib/i18n-helper.js`: `t()`, `translatePage()`, `getLocale()` helpers built on Chrome's native `chrome.i18n` API
- Adds `data-i18n` attributes to `popup.html` and `options.html` for declarative translation
- Replaces all hardcoded French strings in `popup.js`, `options.js`, `status-parser.js`, and `service-worker.js` with `t()` calls
- Converts ~90 French console/debug messages to English across content scripts and service worker
- Manifest `name` and `description` use `__MSG_` substitutions

## Approach

Uses Chrome's native `chrome.i18n.getMessage()` — zero dependencies, no build step required. `default_locale` remains `"fr"` as fallback for unsupported locales. Chrome auto-selects the language based on the user's browser locale.

## Test plan

- [ ] Load unpacked extension in Chrome with **English** browser language — all UI shows English
- [ ] Load in Chrome with **French** browser language — all UI shows French (unchanged)
- [ ] Click through popup views: no-data state, loading, status display, auto-check banner
- [ ] Open options page: all tabs (Historique, Paramètres, Export, Debug)
- [ ] Check `chrome://extensions` — name and description match browser locale
- [ ] Open DevTools console — all log messages are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)