### PR TITLE
fix: onglet Nationalité non détecté en anglais → faux « Site en maintenance »

### DIFF
--- a/content/injected-script.js
+++ b/content/injected-script.js
@@ -419,6 +419,17 @@ QJNdXtE3G7SjkDOn36yZSaXp
     '.fr-tabs__list button, .fr-tabs__list li, li[role="presentation"] a, ' +
     '.p-tabview-nav a, .p-tabview-nav li, [role="tablist"] a, [role="tablist"] li';
 
+  // Le portail ANEF est multilingue : le libellé de l'onglet dépend de la langue
+  // choisie par l'usager (FR « Nationalité Française », EN « French Nationality
+  // application », …). On matche donc sur la racine « national » insensible à la
+  // casse et aux accents, ce qui couvre le français comme l'anglais sans lister
+  // chaque locale. Sans ça, un usager en anglais ne trouve jamais l'onglet, le
+  // fetch expire et l'extension conclut à tort « Site en maintenance ».
+  const _normalize = (s) => (s || '')
+    .normalize('NFD').replace(/[̀-ͯ]/g, '') // enlève les accents
+    .toLowerCase();
+  const _matchesNationality = (s) => _normalize(s).includes('national');
+
   function findNationalityTab() {
     const tabs = document.querySelectorAll(TAB_SELECTOR);
     if (tabs.length > 0 && !_tabsLoggedOnce) {
@@ -426,10 +437,8 @@ QJNdXtE3G7SjkDOn36yZSaXp
       log('🔍 Onglets DOM trouvés: ' + tabs.length + ' — textes: ' + Array.from(tabs).map(el => '"' + (el.textContent || '').trim().substring(0, 40) + '"').join(', '));
     }
     return Array.from(tabs).find(
-      el => el.textContent?.includes("Nationalité Française") ||
-            el.textContent?.includes("Nationalité") ||
-            el.textContent?.includes("nationalité") ||
-            el.getAttribute('aria-label')?.includes("Nationalité")
+      el => _matchesNationality(el.textContent) ||
+            _matchesNationality(el.getAttribute('aria-label'))
     ) || null;
   }
 

--- a/content/injected-script.js
+++ b/content/injected-script.js
@@ -421,14 +421,22 @@ QJNdXtE3G7SjkDOn36yZSaXp
 
   // Le portail ANEF est multilingue : le libellé de l'onglet dépend de la langue
   // choisie par l'usager (FR « Nationalité Française », EN « French Nationality
-  // application », …). On matche donc sur la racine « national » insensible à la
+  // application », …). On matche donc le mot « nationalit{é|y} » insensible à la
   // casse et aux accents, ce qui couvre le français comme l'anglais sans lister
   // chaque locale. Sans ça, un usager en anglais ne trouve jamais l'onglet, le
   // fetch expire et l'extension conclut à tort « Site en maintenance ».
+  //
+  // On exige la racine « nationalit » précédée d'une frontière de mot, et non le
+  // simple radical « national » : ce dernier matcherait « International… » (et
+  // comme ce matcher est l'unique garde avant le fetch, un faux positif
+  // contournerait la voie d'échec `no_nationality_tab` et ferait passer un
+  // dossier non concerné pour une naturalisation). « International » ne contient
+  // pas « nationalit », il est donc bien exclu.
   const _normalize = (s) => (s || '')
     .normalize('NFD').replace(/[̀-ͯ]/g, '') // enlève les accents
     .toLowerCase();
-  const _matchesNationality = (s) => _normalize(s).includes('national');
+  const _NATIONALITY_RE = /\bnationalit[ey]/; // FR « nationalité »→nationalite, EN « nationality »
+  const _matchesNationality = (s) => _NATIONALITY_RE.test(_normalize(s));
 
   function findNationalityTab() {
     const tabs = document.querySelectorAll(TAB_SELECTOR);


### PR DESCRIPTION
## Problème

Sur un compte ANEF configuré **en anglais**, l'extension affiche en boucle « Site en maintenance » alors que le portail et l'API répondent normalement (session valide, `GET /api/anf/dossier-stepper` → HTTP 200).

## Cause

`findNationalityTab()` (`content/injected-script.js`) ne reconnaissait que les libellés **français** de l'onglet :

```js
el.textContent?.includes("Nationalité Française") ||
el.textContent?.includes("Nationalité") ||
el.textContent?.includes("nationalité") ||
el.getAttribute('aria-label')?.includes("Nationalité")
```

En anglais l'onglet s'appelle **« French Nationality application »**, qui ne contient aucune de ces chaînes. Du coup :

1. `findNationalityTab()` renvoie `null` ;
2. `waitForNationalityTab()` tourne jusqu'au timeout de 30 s ;
3. le flux retombe sur la conclusion « maintenance » et l'API du service worker renvoie `{ maintenance: true }` ;
4. le popup (`loadData()` → `response.inMaintenance`) affiche la vue maintenance et le flag reste collé (il n'est ré-effacé que par un fetch dossier réussi, qui ne peut jamais aboutir tant que l'onglet n'est pas trouvé).

À noter : `document.documentElement.lang` reste `"fr"` même quand l'UI est en anglais, donc se baser sur la langue déclarée ne corrige pas le souci — il faut matcher le texte réel de l'onglet.

## Correctif

Matcher le mot **« nationalit{é|y} »** précédé d'une frontière de mot, insensible à la casse et aux accents (NFD), ce qui couvre français + anglais sans énumérer chaque locale :

```js
const _normalize = (s) => (s || '')
  .normalize('NFD').replace(/[̀-ͯ]/g, '')
  .toLowerCase();
const _NATIONALITY_RE = /\bnationalit[ey]/; // FR « nationalité »→nationalite, EN « nationality »
const _matchesNationality = (s) => _NATIONALITY_RE.test(_normalize(s));
```

On exige bien la racine **« nationalit »** et non le simple radical « national » : ce dernier matcherait « International… » et, comme ce matcher est l'unique garde avant le fetch, un faux positif contournerait la voie d'échec `no_nationality_tab` et ferait passer un dossier non concerné pour une naturalisation. « International » ne contient pas « nationalit », il est donc exclu.

Le reste du flux (`waitForTabContent` / `isTabContentLoaded`) s'appuie sur des sélecteurs CSS et des états ARIA (`aria-selected`, `.fr-tabs__panel`, …), sans dépendance à la langue — aucun autre changement nécessaire.

## Tests

Matcher vérifié sur les libellés réels des deux locales + quasi-collisions (12/12 OK) :

| Libellé onglet | Détecté |
|---|---|
| `Nationalité Française` (FR) | ✅ |
| `French Nationality application` (EN) | ✅ |
| `Demande de nationalité française` | ✅ |
| `NATIONALITÉ` | ✅ |
| `International protection request` | ❌ (correct) |
| `Demande de protection internationale` | ❌ (correct) |
| `Residence permit application` | ❌ (correct) |
| `Change of situation request` | ❌ (correct) |

`node --check content/injected-script.js` OK.

## Repro

1. Mettre le portail ANEF en anglais (sélecteur de langue en haut du site).
2. Ouvrir le popup de l'extension sur une session valide.
3. Avant : « Site en maintenance » en boucle. Après : statut affiché normalement.
